### PR TITLE
Added Swedish translation

### DIFF
--- a/src/main/resources/i18n/languages.properties
+++ b/src/main/resources/i18n/languages.properties
@@ -5,3 +5,4 @@ no=Norsk
 pt=Português
 pl=Polski
 nl=Nederlands
+sv=Svenska

--- a/src/main/resources/i18n/sv.properties
+++ b/src/main/resources/i18n/sv.properties
@@ -1,0 +1,94 @@
+global.save=Spara
+global.cancel=Avbryt
+global.delete=Radera
+global.required=Obligatorisk
+
+tree.subscribe=Prenumerera
+tree.import=Importera
+tree.new_category=Ny kategori
+tree.all=Alla
+tree.starred=Stjärnmärkt
+
+subscribe.feed_url=Prenumerationens URL
+subscribe.feed_name=Prenumerationens namn
+subscribe.category=Kategori
+
+import.google_reader_prefix=Låt mig importera dina prenumerationer från ditt
+import.google_reader_suffix=-konto.
+import.google_download=Alternativt, ladda upp din subscriptions.xml-fil.
+import.google_download_link=Ladda ned den här. 
+import.xml_file=XML-fil
+
+new_category.name=Namn
+new_category.parent=Överordnad
+
+toolbar.unread=Oläst
+toolbar.all=Alla
+toolbar.refresh=Uppdatera
+toolbar.mark_all_as_read=Markera alla som lästa
+toolbar.settings=Inställningar
+toolbar.profile=Profil
+toolbar.admin=Administratör
+toolbar.about=Om
+toolbar.logout=Logga ut
+toolbar.donate=Donera
+
+view.error_while_loading_feed=Fel under laddning av denna prenumeration
+view.keep_unread=Håll oläst
+view.no_unread_items=har inga olästa poster.
+
+settings.general=Allmänt
+settings.general.language=Språk
+settings.general.language.contribute=Bidra med översättningar
+settings.general.show_unread=Visa prenumerationer och kategorier utan olästa poster
+settings.general.social_buttons=Visa delningsknappar
+settings.general.scroll_marks=I expanderad vy, markera poster som lästa genom att scrolla förbi dem
+settings.custom_css=Anpassad CSS
+
+details.feed_details=Prenumerationsdetaljer
+details.url=URL
+details.name=Namn
+details.category=Kategori
+details.last_refresh=Senaste uppdatering
+details.feed_url=Prenumerations-URL
+details.generate_api_key_first=Skapa en API-nyckel på din profil först.
+details.unsubscribe=Avprenumerera
+details.category_details=Kategoridetaljer
+details.parent_category=Överordnad kategori
+
+profile.user_name=Användarnamn
+profile.email=E-mail
+profile.change_password=Ändra lösenord
+profile.confirm_password=Bekräfta lösenord
+profile.minimum_6_chars=Minst 6 bokstäver
+profile.passwords_do_not_match=Lösenorden matchar inte
+profile.api_key=API-nyckel
+profile.api_key_not_generated=Inte skapad än
+profile.generate_new_api_key=Skapa ny API-nyckel
+profile.generate_new_api_key_info=Lösenordsbyte skapar ny API-nyckel
+profile.delete_account=Radera konto
+
+about.rest_api=REST-API
+about.keyboard_shortcuts=Tangentbordsgenvägar
+about.line1_prefix=CommaFeed är ett open-source-projekt. Källan är tillgänglig på
+about.line1_suffix=.
+about.line2_prefix=Om du träffar på ett problem, meddela det på problem-sidan för 
+about.line2_suffix=-projektet.
+about.line3=Om du gillar detta projekt, avväg gärna en donation för att stötta utvecklaren och bidra till kostnaderna för att hålla denna site online.
+about.goodies=Godsaker
+about.translation=Översättning
+about.translation.message=Vi behöver din hjälp med att översätta CommaFeed.
+about.translation.link=Se hur du kan bidra med översättningar.
+about.announcements=Notiser
+about.rest_api.line1=CommaFeed är byggt på JAX-RS och AngularJS. Tack vare detta är en REST-API är tillgänglig.
+about.rest_api.link_to_documentation=Länk till dokumentation.
+
+about.shortcuts.mouse_middleclick=mitten-musknapp
+about.shortcuts.open_next_entry=öppna nästa post
+about.shortcuts.open_previous_entry=öppna föregående post
+about.shortcuts.open_close_current_entry=öppna/stäng nuvarande post
+about.shortcuts.open_current_entry_in_new_window=öppna nuvarande post i nytt fönster
+about.shortcuts.star_unstar=stjärnmärk/ostjärnmärk nuvarande post
+about.shortcuts.mark_current_entry=markera nuvarande post läst/oläst
+about.shortcuts.mark_all_as_read=markera alla som lästa
+about.shortcuts.open_in_new_tab_mark_as_read=öppna nuvarande post i ny flik och markera som läst


### PR DESCRIPTION
Complete Swedish translation now in `sv.properties`. Updated
`languages.properties` to reflect this.

There's often a bit of trouble with Swedish translations because of our interesting rule to write several words as one, but this is as dynamic as the language permits.
