### PR TITLE
translated an untranslated word in french

### DIFF
--- a/src/main/resources/i18n/fr.properties
+++ b/src/main/resources/i18n/fr.properties
@@ -76,7 +76,7 @@ profile.passwords_do_not_match=Les mots de passe ne correspondent pas
 profile.api_key=Clé API
 profile.api_key_not_generated=Pas encore générée
 profile.generate_new_api_key=Générer une nouvelle clé API
-profile.generate_new_api_key_info=Changer de password va générer une nouvelle clé API
+profile.generate_new_api_key_info=Changer de mot de passe va générer une nouvelle clé API
 profile.opml_export=Export du fichier OPML
 profile.delete_account=Effacer le compte
 


### PR DESCRIPTION
The word password was still untranslated in a string.
