### PR TITLE
Retrieve favicons using protocol-relative URLs

### DIFF
--- a/src/main/webapp/js/directives.js
+++ b/src/main/webapp/js/directives.js
@@ -43,13 +43,6 @@ module.directive('favicon', function() {
 		template : '<img ng-src="{{iconUrl()}}" class="favicon" onError="this.src=\'images/default_favicon.gif\'"></img>',
 		controller : ['$scope', function($scope) {
 			
-			var firstLetterDomain = function(url) {
-				url = url.replace('http://', '');
-				url = url.replace('https://', '');
-				url = url.replace('www.', '');
-				return url.substring(0, 1);
-			};
-			
 			$scope.iconUrl = function() {
 				var url = $scope.url;
 
@@ -60,10 +53,9 @@ module.directive('favicon', function() {
 					return defaultIcon;
 				}
 				
-				var prefix = firstLetterDomain(url);
 				var index = Math.max(url.length, url.lastIndexOf('?'));
 				
-				var iconUrl = 'http://' + prefix + '.getfavicon.appspot.com/';
+				var iconUrl = '//getfavicon.appspot.com/';
 				iconUrl += encodeURIComponent(url.substring(0, index));
 				iconUrl += '?defaulticon=none';
 				return iconUrl;


### PR DESCRIPTION
If you are serving commafeed over https, many mixed content warnings are thrown
on the getfavicon requests, e.g.:

```
The page at https://commafeed.com/ displayed insecure content from
http://d.getfavicon.appspot.com/http%3A%2F%2Fwww.dailywritingtips.com?defaulticon=none.
```

However, simply removing 'http:' from getfavicon's iconUrl to give a
[protocol-relative url](http://www.paulirish.com/2010/the-protocol-relative-url/) causes some browsers (Chromium) to throw an 'Identity
not verified' error because you are using getfavicon's 'multiple domains'
feature.

Presumably, appspot.com's SSL certificate does not match sub-sub domain's and/or
Chromium has stricter SSL policies (the same thing works in Safari).

We can workaround that by dropping the multiple domain support and hence
removal of the 'firstLetterDomain' function. Hopefully there's not too much of
a performance degradation?
