### PR TITLE
Activate production profile if skipTests defined (#269 workaround)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,11 @@
 		</profile>
 		<profile>
 			<id>prod</id>
+			<activation>
+				<property>
+					<name>skipTests</name>
+				</property>
+			</activation>
 			<properties>
 				<timestamp>${maven.build.timestamp}</timestamp>
 				<production>true</production>


### PR DESCRIPTION
Due to broken pre_build hook on openshift (issue #269) we can't pass custom maven agruments to enable production profile, but we can activate it if 'skipTest' property defined (default for openshift).
