### PR TITLE
Remove duplicate entry title when entries are expanded

### DIFF
--- a/src/main/webapp/sass/components/_entry-list.scss
+++ b/src/main/webapp/sass/components/_entry-list.scss
@@ -78,8 +78,11 @@
 	overflow: hidden;
 	white-space: nowrap;
 	position: absolute;
-	width: 145px;
 	text-overflow: ellipsis;
+}
+
+#feed-accordion .entry-heading .narrow {
+	width: 145px;
 }
 
 #feed-accordion .entry-heading .entry-name {

--- a/src/main/webapp/sass/mobile/_mobile.scss
+++ b/src/main/webapp/sass/mobile/_mobile.scss
@@ -25,6 +25,9 @@
 	#feed-accordion .entry-heading .entry-name {
 		margin-right: 40px;
 	}
+	#feed-accordion .entry-heading .narrow {
+		display: none;
+	}
 	body.left-menu-active .left-menu {
 		display: block !important;
 		width: 100%;

--- a/src/main/webapp/templates/feeds.view.html
+++ b/src/main/webapp/templates/feeds.view.html
@@ -20,7 +20,7 @@
 			ng-class="{unread: entry.read == false, current: current==entry, open: isOpen, closed: !isOpen }">
 			<div class="entry-heading">
 				<a href="{{entry.url}}" target="_blank" class="entry-heading-link" ng-click="noop($event)" ng-mouseup="entryClicked(entry, $event)">
-					<span class="feed-name visible-desktop">
+					<span class="feed-name" ng-class="{narrow: settingsService.settings.viewMode != 'expanded' && !(isOpen && current == entry)}">
 						<span class="star" ng-mouseup="star(entry, !entry.starred, $event)">
 							<i ng-class="{'icon-star icon-star-yellow': entry.starred, 'icon-star-empty': !entry.starred}"
 								class="pointer"></i>
@@ -29,7 +29,7 @@
 						{{entry.feedName}}
 					</span>
 					<span class="entry-date visible-desktop">{{entry.date | entryDate}}</span>
-					<span class="entry-name" ng-class="{shrink: true, rtl: entry.rtl}" ng-bind-html-unsafe="entry.title"></span>
+					<span class="entry-name" ui-if="settingsService.settings.viewMode != 'expanded' && !(isOpen && current == entry)" ng-class="{shrink: true, rtl: entry.rtl}" ng-bind-html-unsafe="entry.title"></span>
 				</a>
 				<a href="{{entry.url}}" target="_blank" class="entry-external-link" ng-click="mark(entry, true)">
 					<i class="icon-external-link"></i>


### PR DESCRIPTION
On expanded entries, entry name is now hidden and feed name is shown entirely.
