### PR TITLE
Choose reading order when using 'next' page

### DIFF
--- a/src/main/java/com/commafeed/frontend/pages/NextUnreadRedirectPage.java
+++ b/src/main/java/com/commafeed/frontend/pages/NextUnreadRedirectPage.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Iterables;
 public class NextUnreadRedirectPage extends WebPage {
 
 	public static final String PARAM_CATEGORYID = "category";
+	public static final String PARAM_READINGORDER = "order";
 
 	@Inject
 	FeedCategoryDAO feedCategoryDAO;
@@ -36,13 +37,19 @@ public class NextUnreadRedirectPage extends WebPage {
 
 	public NextUnreadRedirectPage(PageParameters params) {
 		String categoryId = params.get(PARAM_CATEGORYID).toString();
+		String orderParam = params.get(PARAM_READINGORDER).toString();
 		User user = CommaFeedSession.get().getUser();
+		ReadingOrder order = ReadingOrder.desc;
+		
+		if (!StringUtils.isBlank(orderParam) && orderParam.equals("asc")) {
+			order = ReadingOrder.asc;
+		}
 
 		List<FeedEntryStatus> statuses = null;
 		if (StringUtils.isBlank(categoryId)
 				|| CategoryREST.ALL.equals(categoryId)) {
 			statuses = feedEntryStatusDAO.findAllUnread(user, null, 0, 1,
-					ReadingOrder.desc, true);
+					order, true);
 		} else {
 			FeedCategory category = feedCategoryDAO.findById(user,
 					Long.valueOf(categoryId));
@@ -50,7 +57,7 @@ public class NextUnreadRedirectPage extends WebPage {
 				List<FeedCategory> children = feedCategoryDAO
 						.findAllChildrenCategories(user, category);
 				statuses = feedEntryStatusDAO.findUnreadByCategories(children,
-						null, 0, 1, ReadingOrder.desc, true);
+						null, 0, 1, order, true);
 			}
 		}
 


### PR DESCRIPTION
Coming from Google Reader, the Next bookmarklet was my entire interaction with the website. Being able to read items (especially webcomics and such) in the order they posted is extremely valuable for my use case, so I've added an "order" parameter that can be set to either "desc" or "asc" (defaulting to "desc") to choose the ReadingOrder (e.g. https://www.commafeed.com/next?category=all&order=asc)

I'm kind of new to the site, so I hope I got the protocol right for doing all this :)
