### PR TITLE
fix error with postgresql

### DIFF
--- a/src/main/resources/changelogs/db.changelog-1.0.xml
+++ b/src/main/resources/changelogs/db.changelog-1.0.xml
@@ -352,8 +352,7 @@
 	<changeSet author="athou" id="add-keys">
 		<preConditions onFail="MARK_RAN" onFailMessage="existing table skipping">
 			<not>
-				<foreignKeyConstraintExists foreignKeyTableName="FEEDS" 
-					foreignKeyName="FKE50C03F13BFA4D81" />
+				<primaryKeyExists tableName="FEED_FEEDENTRIES" />
 			</not>
 		</preConditions>
 		<addPrimaryKey columnNames="FEEDENTRY_ID, FEED_ID"


### PR DESCRIPTION
PostgreSQL stores foreign key names in lower case by default, so the precondition was erroneously passing.
Check for the presence of a primary key instead.

This change seems to work with PostgreSQL and the embedded HSQLDB, but I did not try with mySQL or MS SQL Server...
