### PR TITLE
Fix null ptr exception in feed/get/{id} rest call when all entries are read

### DIFF
--- a/src/main/java/com/commafeed/frontend/rest/resources/FeedREST.java
+++ b/src/main/java/com/commafeed/frontend/rest/resources/FeedREST.java
@@ -308,6 +308,9 @@ public class FeedREST extends AbstractResourceREST {
 			return Response.status(Status.NOT_FOUND).build();
 		}
 		Long unreadCount = feedSubscriptionService.getUnreadCount(getUser()).get(id);
+		if (unreadCount == null) {
+			unreadCount = new Long(0);
+		}
 		return Response.ok(
 				Subscription.build(sub, applicationSettingsService.get()
 						.getPublicUrl(), unreadCount)).build();


### PR DESCRIPTION
- map of the unread counts does not contain any element for the feed if
  no entry is unread, leading to a null pointer exception when building
  the response
- problem occurs for example when showing the feed details and all entries
  are read: all fields are blank
