### PR TITLE
Fixing a bidi problem on titles

### DIFF
--- a/src/main/webapp/sass/generic/_misc.scss
+++ b/src/main/webapp/sass/generic/_misc.scss
@@ -6,6 +6,10 @@
 	display: block;
 }
 
+.bidi-embed {
+	unicode-bidi: embed;
+}
+
 .bs-fb ul {
 	margin-bottom: 0px;
 }

--- a/src/main/webapp/templates/_category.html
+++ b/src/main/webapp/templates/_category.html
@@ -11,10 +11,9 @@
 				<i ng-class="{'icon-star' : node.id == 'starred', 'icon-inbox': node.id == 'all'}" ng-show="!showChildren"></i>
 			</span>
 			<span ng-class="{selected: (node.id == selectedId && selectedType == 'category')}">
-				<span ng-class="{unread: unreadCount({category:node})}">
+				<span ng-class="{unread: unreadCount({category:node})}" class="bidi-embed">
 					{{categoryLabel(node)}}
 				</span>
-				&lrm;
 				<span class="unread-counter">
 					{{categoryCountLabel(node)}}
 				</span>
@@ -38,10 +37,9 @@
 				href="{{feed.feedLink}}" target="_blank"
 				ng-class="{error: feed.message && feed.errorCount > 10, selected: (feed.id == selectedId && selectedType == 'feed') }">
 				<favicon url="feed.iconUrl" />
-				<span ng-class="{unread: feed.unread}">
+				<span ng-class="{unread: feed.unread}" class="bidi-embed">
 					{{feed.name}}
-				</span> 
-				&lrm;
+				</span>
 				<span class="unread-counter">
 					{{feedCountLabel(feed)}}
 				</span>

--- a/src/main/webapp/templates/feeds.view.html
+++ b/src/main/webapp/templates/feeds.view.html
@@ -46,7 +46,7 @@
 						<div class="entry-subtitle">
 							<span class="entry-source" ui-if="selectedType == 'category'">
 								<span class="entry-source-prefix">${view.entry_source}</span>
-								<a ng-click="goToFeed(entry.feedId)" class="pointer"><span>{{entry.feedName}}</span></a>
+								<a ng-click="goToFeed(entry.feedId)" class="pointer bidi-embed"><span>{{entry.feedName}}</span></a>
 							</span>
 							<span class="entry-author" ui-if="entry.author">
 								<span class="entry-author-prefix">${view.entry_author}</span>


### PR DESCRIPTION
- It is less hackish than lrm (it will be usful in a complete RTL UI also) but please refactoring bidi-embed class if needed (rename, if needed)
- lrm was making an extra space for all, so this is fixup for it

This is revert of https://github.com/Athou/commafeed/issues/257 somehow but it doesn't break its functionallity, tested
### where lrm was used

Before https://github.com/Athou/commafeed/issues/257
![2013-07-11 10_24_26-8 - commafeed](https://f.cloud.github.com/assets/833473/779834/8abd17f2-e9ee-11e2-9b6f-bfe0f3c1abb2.png)
After https://github.com/Athou/commafeed/issues/257
![2013-07-11 10_24_59-8 - commafeed](https://f.cloud.github.com/assets/833473/779838/996789fe-e9ee-11e2-8d88-905c4e300aa7.png)
After this commit
![2013-07-11 10_25_29-8 - commafeed](https://f.cloud.github.com/assets/833473/779841/a0fe1250-e9ee-11e2-80ec-39436a1d2e07.png)
#### Extra space was everywhere

Before this commit:
![2013-07-11 10_38_55-7 - commafeed](https://f.cloud.github.com/assets/833473/779882/7d19aa32-e9f0-11e2-85c8-8c360e8efd70.png)
After:
![2013-07-11 10_39_13-7 - commafeed](https://f.cloud.github.com/assets/833473/779883/82ca5576-e9f0-11e2-8997-5d36810b2c33.png)
### on view.entry_source

Before this:
![2013-07-11 10_31_16-6 - commafeed](https://f.cloud.github.com/assets/833473/779865/98869f2e-e9ef-11e2-9fe3-cead082d5a4d.png)
After:
![2013-07-11 10_31_00-5 - commafeed](https://f.cloud.github.com/assets/833473/779867/a1dc687e-e9ef-11e2-9f66-1756b9fd8eec.png)

P.S. Nevermind about such these problems, I am here to fix them forever! :P
