### PR TITLE
Fix a few issues related to recent database changelog updates

### DIFF
--- a/src/main/resources/changelogs/db.changelog-1.1.xml
+++ b/src/main/resources/changelogs/db.changelog-1.1.xml
@@ -281,6 +281,7 @@
 	</changeSet>
 	
 	<changeSet author="athou" id="denormalize-statuses">
+		<validCheckSum>7:c73f70fbcbc8bb30f9629028ec8ddb06</validCheckSum>
 		<addColumn tableName="FEEDENTRYSTATUSES">
 			<column name="user_id" type="BIGINT" defaultValue="1">
 				<constraints nullable="false" />


### PR DESCRIPTION
Hi,

I had a few issues with the new DB changelogs submitted in change 24ee418f3f307bbc0e40dafbbdd682c01c8f482d:
- HSQLDB did not like setting a column to non-NULL with no default value given. I gave a default value to make it happy, but maybe there is a better way to fix this? Let me know if you would like me to alter this change...
- PostgreSQL rejected a few SQL update statements too.

These changes seems to work fine with HSQLDB and pgSQL, but I did not try with mySQL or MS SQL.

CommaFeed is great! Thanks!
