### PR TITLE
Mark Read button now respects filters

### DIFF
--- a/src/main/app/js/controllers.js
+++ b/src/main/app/js/controllers.js
@@ -489,6 +489,7 @@ module.controller('ToolbarCtrl', [
 					type : $stateParams._type,
 					id : $stateParams._id,
 					olderThan : olderThan,
+					keywords: $location.search().q,
 					read : true
 				});
 			};
@@ -881,6 +882,7 @@ module.controller('FeedListCtrl', [
 				service.mark({
 					id : $scope.selectedId,
 					olderThan : olderThan || $scope.timestamp,
+					keywords: $location.search().q,
 					read : true
 				}, function() {
 					CategoryService.refresh(function() {

--- a/src/main/java/com/commafeed/backend/service/FeedEntryService.java
+++ b/src/main/java/com/commafeed/backend/service/FeedEntryService.java
@@ -65,8 +65,8 @@ public class FeedEntryService {
 		feedEntryStatusDAO.saveOrUpdate(status);
 	}
 
-	public void markSubscriptionEntries(User user, List<FeedSubscription> subscriptions, Date olderThan) {
-		List<FeedEntryStatus> statuses = feedEntryStatusDAO.findBySubscriptions(user, subscriptions, true, null, null, -1, -1, null, false,
+	public void markSubscriptionEntries(User user, List<FeedSubscription> subscriptions, Date olderThan, String keywords) {
+		List<FeedEntryStatus> statuses = feedEntryStatusDAO.findBySubscriptions(user, subscriptions, true, keywords, null, -1, -1, null, false,
 				false, null);
 		markList(statuses, olderThan);
 		cache.invalidateUnreadCount(subscriptions.toArray(new FeedSubscription[0]));

--- a/src/main/java/com/commafeed/frontend/model/request/MarkRequest.java
+++ b/src/main/java/com/commafeed/frontend/model/request/MarkRequest.java
@@ -24,6 +24,9 @@ public class MarkRequest implements Serializable {
 			required = false)
 	private Long olderThan;
 
+	@ApiModelProperty(value = "only mark read if a feed has these keywords in the title or rss content", required = false)
+	private String keywords;
+	
 	@ApiModelProperty(value = "if marking a category or 'all', exclude those subscriptions from the marking", required = false)
 	private List<Long> excludedSubscriptions;
 

--- a/src/main/java/com/commafeed/frontend/resource/CategoryREST.java
+++ b/src/main/java/com/commafeed/frontend/resource/CategoryREST.java
@@ -243,11 +243,12 @@ public class CategoryREST {
 		Preconditions.checkNotNull(req.getId());
 
 		Date olderThan = req.getOlderThan() == null ? null : new Date(req.getOlderThan());
+		String keywords = req.getKeywords();
 
 		if (ALL.equals(req.getId())) {
 			List<FeedSubscription> subs = feedSubscriptionDAO.findAll(user);
 			removeExcludedSubscriptions(subs, req.getExcludedSubscriptions());
-			feedEntryService.markSubscriptionEntries(user, subs, olderThan);
+			feedEntryService.markSubscriptionEntries(user, subs, olderThan, keywords);
 		} else if (STARRED.equals(req.getId())) {
 			feedEntryService.markStarredEntries(user, olderThan);
 		} else {
@@ -255,7 +256,7 @@ public class CategoryREST {
 			List<FeedCategory> categories = feedCategoryDAO.findAllChildrenCategories(user, parent);
 			List<FeedSubscription> subs = feedSubscriptionDAO.findByCategories(user, categories);
 			removeExcludedSubscriptions(subs, req.getExcludedSubscriptions());
-			feedEntryService.markSubscriptionEntries(user, subs, olderThan);
+			feedEntryService.markSubscriptionEntries(user, subs, olderThan, keywords);
 		}
 		return Response.ok().build();
 	}

--- a/src/main/java/com/commafeed/frontend/resource/FeedREST.java
+++ b/src/main/java/com/commafeed/frontend/resource/FeedREST.java
@@ -287,10 +287,11 @@ public class FeedREST {
 		Preconditions.checkNotNull(req.getId());
 
 		Date olderThan = req.getOlderThan() == null ? null : new Date(req.getOlderThan());
+		String keywords = req.getKeywords();
 
 		FeedSubscription subscription = feedSubscriptionDAO.findById(user, Long.valueOf(req.getId()));
 		if (subscription != null) {
-			feedEntryService.markSubscriptionEntries(user, Arrays.asList(subscription), olderThan);
+			feedEntryService.markSubscriptionEntries(user, Arrays.asList(subscription), olderThan, keywords);
 		}
 		return Response.ok().build();
 	}


### PR DESCRIPTION
I think this is another pretty good change. As a user of CommaFeed, I was surprised when I clicked the "mark all as read" button after filtering the results and it went ahead and marked every entry as read for the entire feed instead of just the ones visible, the ones I had filtered.

This patch is meant to help manage jumbled feeds intertwined with entries that you are interested in and those you aren't interested in. The ones that you aren't interested in can be marked as read now all at once instead of individually, if you can find a good search query which gets them all in the same room.
e.g., if I subscribe to a youtuber via rss, and they are always uploading a few series I don't like, but I still want to see all the other series, I can just type the names of the series I don't like, and click "Mark Read" to get rid of only the ones I don't like, which makes looking at the entries I do want to see much easier.
