### PR TITLE
fix for #734 and allowing version bump of minicss

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,7 +79,7 @@ gulp.task('build', ['images', 'i18n', 'resources', 'sass', 'fonts', 'select2', '
 	var cssFilter = filter("**/*.css");
 	return gulp.src([SRC_DIR + 'index.html', TEMP_DIR + 'app.css']).pipe(assets)
 
-	.pipe(cssFilter).pipe(minifyCSS()).pipe(cssFilter.restore())
+	.pipe(cssFilter).pipe(minifyCSS({rebase: false})).pipe(cssFilter.restore())
 
 	.pipe(jsFilter).pipe(uglify()).pipe(jsFilter.restore())
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "gulp": "3.8.11",
     "gulp-rev": "4.0.0",
     "gulp-rev-replace": "0.4.1",
-    "gulp-minify-css": "1.1.0",
+    "gulp-minify-css": "1.1.3",
     "gulp-uglify": "1.2.0",
     "gulp-filter": "2.0.2",
     "gulp-connect": "2.2.0",


### PR DESCRIPTION
adding rebase = false allows safe version upgrade of gulp-minify-css