### PR TITLE
Add rel="noreferrer" to resolve window.opener issue

### DIFF
--- a/src/main/app/templates/feeds.view.html
+++ b/src/main/app/templates/feeds.view.html
@@ -6,7 +6,7 @@
 				<span ng-switch-when="starred">{{ 'tree.starred' | translate }}</span>
 				<span ng-switch-default>
 					<span ng-hide="feedLink">{{name}}</span>
-					<a ng-show="feedLink" href="{{feedLink}}" target="_blank">{{name}}</a>
+					<a ng-show="feedLink" href="{{feedLink}}" target="_blank" rel="noreferrer">{{name}}</a>
 				</span>
 			</span>
 			<span ng-show="name"> &#187;</span>
@@ -20,7 +20,7 @@
 		<div ng-repeat="entry in entries" class="entry entry-font-size-{{font_size}}" id="entry_{{entry.id}}"
 			ng-class="{unread: entry.read == false, current: current==entry, open: isOpen, closed: !isOpen }">
 			<div class="entry-heading" ng-swipe-right="mark(entry, !entry.read)">
-				<a href="{{entry.url}}" target="_blank" class="entry-heading-link" ng-click="noop($event)" ng-mouseup="entryClicked(entry, $event)">
+				<a href="{{entry.url}}" target="_blank" rel="noreferrer" class="entry-heading-link" ng-click="noop($event)" ng-mouseup="entryClicked(entry, $event)">
 					<span class="feed-name">
 						<span class="star" ng-mouseup="star(entry, !entry.starred, $event)">
 							<i ng-class="{'icon-star icon-star-yellow': entry.starred, 'icon-star-empty': !entry.starred}" class="pointer"></i>

--- a/src/main/java/com/commafeed/backend/feed/FeedUtils.java
+++ b/src/main/java/com/commafeed/backend/feed/FeedUtils.java
@@ -92,6 +92,7 @@ public class FeedUtils {
 		whitelist.addProtocols("q", "cite", "http", "https");
 
 		whitelist.addEnforcedAttribute("a", "target", "_blank");
+		whitelist.addEnforcedAttribute("a", "rel", "noreferrer");
 		return whitelist;
 	}
 


### PR DESCRIPTION
https://mathiasbynens.github.io/rel-noopener
I've added rel="noreferrer" to the common places external links are available and will be clicked but I can add to the other target=_blank if you wish so.

Both of rel=noopener and rel=noreferrer can be used to resolve window.opener issue but I personally prefer the latter as it disables Referrer header also. However if you don't like Referrer header to be vanished, I am open to change the patch to use the less adopted "noopener".

BTW, thank you very much for keeping up the project all these years :)