### PR TITLE
Use Safari transparent tab bar as loading progress indicator

### DIFF
--- a/src/main/app/sass/components/_loading-bar.scss
+++ b/src/main/app/sass/components/_loading-bar.scss
@@ -1,5 +1,8 @@
 #loading-bar .bar {
 	background: #2c3e50;
+	height: 101px;
+	top: -100px;
+	position: fixed;
 }
 
 #loading-bar .peg {


### PR DESCRIPTION
Using this little trick, loading-bar fills transparent background of Safari's tab bar menu and makes a nice effect with little hassle.