### PR TITLE
Add feature to emit Graphite metrics based on configuration

### DIFF
--- a/config.dev.yml
+++ b/config.dev.yml
@@ -28,6 +28,14 @@ app:
   smtpTls: false
   smtpUserName: user
   smtpPassword: pass
+
+  # Graphite Metric settings
+  # Allows those who use Graphite to have CommaFeed send metrics for graphing (time in seconds)
+  graphiteEnabled: false
+  graphitePrefix: "test.commafeed"
+  graphiteHost: "localhost"
+  graphitePort: 2003
+  graphiteInterval: 60
   
   # wether this commafeed instance has a lot of feeds to refresh
   # leave this to false in almost all cases

--- a/config.yml.example
+++ b/config.yml.example
@@ -29,6 +29,14 @@ app:
   smtpUserName:
   smtpPassword:
   smtpFromAddress:
+
+  # Graphite Metric settings
+  # Allows those who use Graphite to have CommaFeed send metrics for graphing (time in seconds)
+  graphiteEnabled: false
+  graphitePrefix: "test.commafeed"
+  graphiteHost: "localhost"
+  graphitePort: 2003
+  graphiteInterval: 60
   
   # wether this commafeed instance has a lot of feeds to refresh
   # leave this to false in almost all cases

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+                <dependency>
+                        <groupId>io.dropwizard.metrics</groupId>
+                        <artifactId>metrics-graphite</artifactId>
+                        <version>3.1.2</version>
+                </dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/commafeed/CommaFeedConfiguration.java
+++ b/src/main/java/com/commafeed/CommaFeedConfiguration.java
@@ -96,6 +96,12 @@ public class CommaFeedConfiguration extends Configuration {
 		private String smtpPassword;
 		private String smtpFromAddress;
 
+		private boolean graphiteEnabled;
+		private String graphitePrefix;
+		private String graphiteHost;
+		private int graphitePort;
+		private int graphiteInterval;
+
 		@NotNull
 		@Valid
 		private Boolean heavyLoad;

--- a/src/main/java/com/commafeed/CommaFeedModule.java
+++ b/src/main/java/com/commafeed/CommaFeedModule.java
@@ -1,5 +1,7 @@
 package com.commafeed;
 
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -7,6 +9,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.SessionFactory;
 
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.graphite.Graphite;
+import com.codahale.metrics.graphite.GraphiteReporter;
+import com.codahale.metrics.MetricFilter;
+import com.commafeed.CommaFeedConfiguration.ApplicationSettings;
 import com.commafeed.CommaFeedConfiguration.CacheType;
 import com.commafeed.backend.cache.CacheService;
 import com.commafeed.backend.cache.NoopCacheService;
@@ -54,5 +60,27 @@ public class CommaFeedModule extends AbstractModule {
 		taskMultibinder.addBinding().to(OldEntriesCleanupTask.class);
 		taskMultibinder.addBinding().to(OrphanedFeedsCleanupTask.class);
 		taskMultibinder.addBinding().to(OrphanedContentsCleanupTask.class);
+
+		ApplicationSettings settings = config.getApplicationSettings();
+
+		if (settings.isGraphiteEnabled()) {
+			final String graphitePrefix = settings.getGraphitePrefix();
+			final String graphiteHost = settings.getGraphiteHost();
+			final int graphitePort = settings.getGraphitePort();
+			final int graphiteInterval = settings.getGraphiteInterval();
+
+			log.info("Graphite Metrics will be sent to host={}, port={}, prefix={}, interval={}sec", graphiteHost, graphitePort, graphitePrefix, graphiteInterval);
+
+			final Graphite graphite = new Graphite(new InetSocketAddress(graphiteHost, graphitePort));
+			final GraphiteReporter reporter = GraphiteReporter.forRegistry(metrics)
+			                                                  .prefixedWith(graphitePrefix)
+			                                                  .convertRatesTo(TimeUnit.SECONDS)
+			                                                  .convertDurationsTo(TimeUnit.MILLISECONDS)
+			                                                  .filter(MetricFilter.ALL)
+			                                                  .build(graphite);
+			reporter.start(graphiteInterval, TimeUnit.SECONDS);
+		} else {
+			log.info("Graphite Metrics Disabled. Metrics will not be sent.");
+		}
 	}
 }


### PR DESCRIPTION
I've created a patch that allows those who use Graphite to configure the dropwizard-metrics library to emit those metrics to a Graphite compatible endpoint for longer term retention and graphing over time.

Here is an example graph showing some of the metrics emitted by dropwizard-metrics using the metrics-graphite plugin:
![commafeed_graphite_example](https://user-images.githubusercontent.com/7005728/27893896-6be8863e-61ce-11e7-96bc-dfd8b4477362.png)

If the graphite configurations (provided in the examples) are left out of the config file completely, or are set to false, dropwizard-metrics won't enable Graphite reporting at all.