### PR TITLE
Set iOS Meta Tags to use Full Screen 'default' status bar

### DIFF
--- a/src/main/app/index.html
+++ b/src/main/app/index.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 <meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-status-bar-style" content="default">
 <meta name="mobile-web-app-capable" content="yes">
 <link rel="manifest" href="manifest.json">
 <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />


### PR DESCRIPTION
Resolves the issue of the overlapping/poor looking iOS status bar.

Closes #842 