### PR TITLE
Use tinycon to display unread article count

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v 2.5.0
+  - unread count is now displayed in a favicon badge when supported
+
 v 2.4.0
   - users were not able to change password or delete account
   - fix api key generation

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,8 @@
     "devicejs": "0.2.4",
     "readabilicons": "arc90/readability-readabilicons#34c55561c5b8ec6e90714b50237c06b13cb9d59c",
     "zocial-less": "1.0.0",
-	"swagger-ui": "2.1.0"
+	"swagger-ui": "2.1.0",
+	"tinycon": "0.6.5"
   },
   "resolutions": {
     "angular": "1.3.14",

--- a/src/main/app/index.html
+++ b/src/main/app/index.html
@@ -70,6 +70,7 @@
 	<script type="text/javascript" src="lib/mousetrap/mousetrap.js"></script>
 	<script type="text/javascript" src="lib/momentjs/min/moment-with-locales.js"></script>
 	<script type="text/javascript" src="lib/devicejs/lib/device.js"></script>
+	<script type="text/javascript" src="lib/tinycon/tinycon.js"></script>
 	
 	<script type="text/javascript" src="js/controllers.js"></script>
 	<script type="text/javascript" src="js/directives.js"></script>

--- a/src/main/app/js/controllers.js
+++ b/src/main/app/js/controllers.js
@@ -194,11 +194,7 @@ module.controller('CategoryTreeCtrl', [
 			};
 
 			$scope.$watch(rootUnreadCount, function(value) {
-				var label = 'CommaFeed';
-				if (value > 0) {
-					label = '(' + value + ') ' + label;
-				}
-				$window.document.title = label;
+				Tinycon.setBubble(value);
 			});
 
 			var mark = function(node, entry) {


### PR DESCRIPTION
This PR uses [Tinycon](https://github.com/tommoor/tinycon/) to replace the unread count in the tab title with a favicon badge:
<img width="268" alt="screen shot 2017-08-18 at 08 11 08" src="https://user-images.githubusercontent.com/1444515/29446529-f0aa9426-83ec-11e7-919b-225f6d494f48.png">

Here's what it looks like on a pinned tab:
<img width="47" alt="screen shot 2017-08-18 at 08 11 18" src="https://user-images.githubusercontent.com/1444515/29446527-f0a7e046-83ec-11e7-87f3-63c7f8131693.png">

I've tested this in Firefox (works), Chrome (works), and Safari 10 (doesn't work, falls back to displaying unread count in tab title). More information on browser support can be found [here](https://github.com/tommoor/tinycon/#browser-support).

