### PR TITLE
Autorefresh feed on activating CommaFeed's tab

### DIFF
--- a/src/main/app/js/controllers.js
+++ b/src/main/app/js/controllers.js
@@ -861,6 +861,16 @@ module.controller('FeedListCtrl', [
 				return $window.off('scroll', scrollListener);
 			});
 
+			var refreshHandler = function() {
+				if ((document.visibilityState === 'visible') && (!$scope.isOpen) && (SettingsService.settings.viewMode !== 'expanded')) {
+					$scope.$emit('emitReload');
+				}
+			};
+			$window.on('visibilitychange', refreshHandler);
+			$scope.$on('$destroy', function() {
+				return $window.off('visibilitychange', refreshHandler);
+			});
+
 			$scope.goToFeed = function(id) {
 				$state.transitionTo('feeds.view', {
 					_type : 'feed',

--- a/src/main/app/js/controllers.js
+++ b/src/main/app/js/controllers.js
@@ -1269,6 +1269,7 @@ module.controller('FeedListCtrl', [
 				$scope.timestamp = 0;
 				$scope.busy = false;
 				$scope.hasMore = true;
+				$scope.isOpen = SettingsService.settings.viewMode == 'expanded';
 				$scope.loadMoreEntries();
 
 				if (all) {


### PR DESCRIPTION
The favicon counter refreshes automatically, but open feed does not.
Let's fix it by autorefreshing the feed when user activates the CommaFeed tab
in their browser.

To prevent interruptions when reading and switching between tabs (for external
links for example), do it only when no entry is open.