### PR TITLE
workaround for youtube channels

### DIFF
--- a/src/main/java/com/commafeed/backend/feed/FeedFetcher.java
+++ b/src/main/java/com/commafeed/backend/feed/FeedFetcher.java
@@ -2,6 +2,7 @@ package com.commafeed.backend.feed;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.regex.*;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -96,8 +97,24 @@ public class FeedFetcher {
 				foundUrl = atom.get(0).attr("abs:href");
 			} else if (!rss.isEmpty()) {
 				foundUrl = rss.get(0).attr("abs:href");
+			} else {
+				foundUrl = extractYoutubeFeedUrl(baseUri);
 			}
 		}
 		return foundUrl;
+	}
+
+	/*
+	* Workaround for Youtube channels:
+	* convert the channel URL to the valid feed URL
+	* https://www.youtube.com/channel/CHANNEL_ID
+	* https://www.youtube.com/feeds/videos.xml?channel_id=CHANNEL_ID
+	*/
+	private String extractYoutubeFeedUrl(String url) {
+		Pattern regexp = Pattern.compile("(.*\\byoutube\\.com)\\/channel\\/([^\\/]+)", Pattern.CASE_INSENSITIVE);
+		Matcher matcher = regexp.matcher(url);
+		if ( matcher.find() ) {
+			return matcher.group(1) + "/feeds/videos.xml?channel_id=" + matcher.group(2);
+		}
 	}
 }

--- a/src/main/java/com/commafeed/backend/feed/FeedFetcher.java
+++ b/src/main/java/com/commafeed/backend/feed/FeedFetcher.java
@@ -113,8 +113,6 @@ public class FeedFetcher {
 	private String extractYoutubeFeedUrl(String url) {
 		Pattern regexp = Pattern.compile("(.*\\byoutube\\.com)\\/channel\\/([^\\/]+)", Pattern.CASE_INSENSITIVE);
 		Matcher matcher = regexp.matcher(url);
-		if ( matcher.find() ) {
-			return matcher.group(1) + "/feeds/videos.xml?channel_id=" + matcher.group(2);
-		}
+		return matcher.find() ? matcher.group(1) + "/feeds/videos.xml?channel_id=" + matcher.group(2) : null;
 	}
 }


### PR DESCRIPTION
Hi Jérémie,

I would like to discuss the workaround solution for youtube channels that should resolve the issue #785. 

I am not sure it this modification is placed in right component. Most probably the `FeedFetcher#extractYoutubeFeedUrl()` method should be placed as the part of the `FeedUtils` component. 

It checks the youtube channel URL and replaces it with youtube feed URL accordingly the following examples. To be honest, I didn't test it yet. I believe it may cover the issue with youtube channels not having the reference to the feed. 

channel URL
```
https://www.youtube.com/channel/CHANNEL_ID
```
feed URL
```
https://www.youtube.com/feeds/videos.xml?channel_id=CHANNEL_ID
```

Ildar