### PR TITLE
Add tests for PubSubService and FeedUtils.removeTrailingSlash()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.12</version>
+			<version>1.7.30</version>
 		</dependency>
 
 		<dependency>
@@ -481,6 +481,12 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>2.0.11-beta</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mock-server</groupId>
+			<artifactId>mockserver-junit-rule</artifactId>
+			<version>5.11.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/test/java/com/commafeed/backend/feed/FeedUtilsTest.java
+++ b/src/test/java/com/commafeed/backend/feed/FeedUtilsTest.java
@@ -78,4 +78,19 @@ public class FeedUtilsTest {
 		String source = "<source>T&acute;l&acute;phone &prime;</source>";
 		Assert.assertEquals("<source>T&#180;l&#180;phone &#8242;</source>", FeedUtils.replaceHtmlEntitiesWithNumericEntities(source));
 	}
+
+	@Test
+	public void testRemoveTrailingSlash() {
+		final String url = "http://localhost/";
+		final String result = FeedUtils.removeTrailingSlash(url);
+		Assert.assertEquals("http://localhost", result);
+	}
+
+	@Test
+	public void testRemoveTrailingSlash_lastSlashOnly() {
+		final String url = "http://localhost//";
+		final String result = FeedUtils.removeTrailingSlash(url);
+		Assert.assertEquals("http://localhost/", result);
+	}
+
 }

--- a/src/test/java/com/commafeed/backend/service/PubSubServiceTest.java
+++ b/src/test/java/com/commafeed/backend/service/PubSubServiceTest.java
@@ -1,0 +1,104 @@
+package com.commafeed.backend.service;
+
+import com.commafeed.CommaFeedConfiguration;
+import com.commafeed.backend.feed.FeedQueues;
+import com.commafeed.backend.model.Feed;
+import org.apache.http.HttpHeaders;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.MockServerRule;
+import org.mockserver.model.MediaType;
+
+import static org.mockito.Mockito.*;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PubSubServiceTest {
+
+    PubSubService underTest;
+
+    @Rule
+    public MockServerRule mockServerRule = new MockServerRule(this, 22441);
+    public MockServerClient mockServerClient;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    CommaFeedConfiguration config;
+
+    @Mock
+    FeedQueues queues;
+
+    @Mock
+    Feed feed;
+
+
+    @Before
+    public void init() {
+        underTest = new PubSubService(config, queues);
+
+        // setup feed
+        feed = mock(Feed.class);
+        when(feed.getPushHub()).thenReturn("http://localhost:22441/hub");
+        when(feed.getPushTopic()).thenReturn("foo");
+
+        // setup config
+        when(config.getApplicationSettings().getPublicUrl()).thenReturn("http://localhost:22441/hub");
+    }
+
+    @Test
+    public void subscribe_200() {
+        // Arrange
+        mockServerClient
+                .when(request().withMethod("POST"))
+                .respond(response().withStatusCode(200));
+
+        // Act
+        underTest.subscribe(feed);
+
+        // Assert
+        mockServerClient.verify(request()
+                .withContentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .withHeader(HttpHeaders.USER_AGENT, "CommaFeed")
+                .withMethod("POST")
+                .withPath("/hub"));
+        verify(feed, never()).setPushTopic(anyString());
+        verifyZeroInteractions(queues);
+    }
+
+    @Test
+    public void subscribe_400_withPushpressError() {
+        // Arrange
+        mockServerClient
+                .when(request().withMethod("POST"))
+                .respond(response().withStatusCode(400).withBody(" is value is not allowed.  You may only subscribe to"));
+
+        // Act
+        underTest.subscribe(feed);
+
+        // Assert
+        verify(feed).setPushTopic(anyString());
+        verify(queues).giveBack(feed);
+    }
+
+    @Test
+    public void subscribe_400_withoutPushpressError() {
+        // Arrange
+        mockServerClient
+                .when(request().withMethod("POST"))
+                .respond(response().withStatusCode(400));
+
+        // Act
+        underTest.subscribe(feed);
+
+        // Assert
+        verify(feed, never()).setPushTopic(anyString());
+        verifyZeroInteractions(queues);
+    }
+
+}


### PR DESCRIPTION
I've added some tests to increase code coverage and as preparation for a refactoring of `PubSubService`