### PR TITLE
Refactor the FeedEntryTagService

### DIFF
--- a/src/main/java/com/commafeed/backend/service/FeedEntryTagService.java
+++ b/src/main/java/com/commafeed/backend/service/FeedEntryTagService.java
@@ -1,19 +1,18 @@
 package com.commafeed.backend.service;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
-import lombok.RequiredArgsConstructor;
-
 import com.commafeed.backend.dao.FeedEntryDAO;
 import com.commafeed.backend.dao.FeedEntryTagDAO;
 import com.commafeed.backend.model.FeedEntry;
 import com.commafeed.backend.model.FeedEntryTag;
 import com.commafeed.backend.model.User;
+import com.google.common.annotations.VisibleForTesting;
+import lombok.RequiredArgsConstructor;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor(onConstructor = @__({ @Inject }))
 @Singleton
@@ -27,16 +26,37 @@ public class FeedEntryTagService {
 		if (entry == null) {
 			return;
 		}
-
+	
 		List<FeedEntryTag> existingTags = feedEntryTagDAO.findByEntry(user, entry);
-		Set<String> existingTagNames = existingTags.stream().map(t -> t.getName()).collect(Collectors.toSet());
+		Set<String> existingTagNames = getTagNames(existingTags);
 
-		List<FeedEntryTag> addList = tagNames.stream().filter(name -> !existingTagNames.contains(name))
-				.map(name -> new FeedEntryTag(user, entry, name)).collect(Collectors.toList());
-		List<FeedEntryTag> removeList = existingTags.stream().filter(tag -> !tagNames.contains(tag.getName())).collect(Collectors.toList());
+		List<FeedEntryTag> addList = getAddList(user, entry, tagNames, existingTagNames);
+		List<FeedEntryTag> removeList = getRemoveList(existingTags, tagNames);
 
 		feedEntryTagDAO.saveOrUpdate(addList);
 		feedEntryTagDAO.delete(removeList);
+	}
+
+	@VisibleForTesting
+	List<FeedEntryTag> getAddList(User user, FeedEntry entry, List<String> tagNames, Set<String> existingTagNames) {
+		return tagNames.stream()
+				.filter(name -> !existingTagNames.contains(name))
+				.map(name -> new FeedEntryTag(user, entry, name))
+				.collect(Collectors.toList());
+	}
+
+	@VisibleForTesting
+	List<FeedEntryTag> getRemoveList(List<FeedEntryTag> existingTags, List<String> tagNames) {
+		return existingTags.stream()
+				.filter(tag -> !tagNames.contains(tag.getName()))
+				.collect(Collectors.toList());
+	}
+
+	@VisibleForTesting
+	Set<String> getTagNames(List<FeedEntryTag> tags) {
+		return tags.stream()
+				.map(FeedEntryTag::getName)
+				.collect(Collectors.toSet());
 	}
 
 }

--- a/src/test/java/com/commafeed/backend/service/FeedEntryTagServiceTest.java
+++ b/src/test/java/com/commafeed/backend/service/FeedEntryTagServiceTest.java
@@ -1,0 +1,134 @@
+package com.commafeed.backend.service;
+
+import com.commafeed.backend.dao.FeedEntryDAO;
+import com.commafeed.backend.dao.FeedEntryTagDAO;
+import com.commafeed.backend.model.FeedEntry;
+import com.commafeed.backend.model.FeedEntryTag;
+import com.commafeed.backend.model.User;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FeedEntryTagServiceTest {
+
+    private FeedEntryTagService underTest;
+
+    @Mock
+    private FeedEntryDAO feedEntryDAO;
+
+    @Mock
+    private FeedEntryTagDAO feedEntryTagDAO;
+
+    @Captor
+    private ArgumentCaptor<List<FeedEntryTag>> feedEntryListArgumentCaptor;
+
+    @Before
+    public void init() {
+        underTest = new FeedEntryTagService(feedEntryDAO, feedEntryTagDAO);
+    }
+
+    @Test
+    public void updateTags() {
+        // Arrange
+        final User user = new User();
+        final FeedEntry entry = new FeedEntry();
+        final List<String> tagNames = Lists.newArrayList("tag1", "tag2");
+        final FeedEntryTag tag1 = new FeedEntryTag(user, entry, "tag1");
+        final FeedEntryTag tag3 = new FeedEntryTag(user, entry, "tag3");
+        final ArrayList<FeedEntryTag> existingTags = Lists.newArrayList(tag1, tag3);
+
+        when(feedEntryDAO.findById(1L)).thenReturn(entry);
+        when(feedEntryTagDAO.findByEntry(user, entry)).thenReturn(existingTags);
+
+        // Act
+        underTest.updateTags(user, 1L, tagNames);
+
+        // Assert
+        verify(feedEntryTagDAO).saveOrUpdate(feedEntryListArgumentCaptor.capture());
+        assertEquals(1, feedEntryListArgumentCaptor.getValue().size());
+        assertEquals("tag2", feedEntryListArgumentCaptor.getValue().get(0).getName());
+        verify(feedEntryTagDAO).delete(feedEntryListArgumentCaptor.capture());
+        assertEquals(1, feedEntryListArgumentCaptor.getValue().size());
+        assertEquals("tag3", feedEntryListArgumentCaptor.getValue().get(0).getName());
+    }
+
+    @Test
+    public void updateTags_entryDoesNotExist() {
+        // Arrange
+        final User user = new User();
+        final List<String> tagNames = Lists.newArrayList("tag1", "tag2");
+        when(feedEntryDAO.findById(1L)).thenReturn(null);
+
+        // Act
+        underTest.updateTags(user, 1L, tagNames);
+
+        // Assert
+        verifyZeroInteractions(feedEntryTagDAO);
+    }
+
+    @Test
+    public void getTagNames() {
+        // Arrange
+        final FeedEntryTag tag1 = new FeedEntryTag(new User(), new FeedEntry(), "tag1");
+        final FeedEntryTag tag2 = new FeedEntryTag(new User(), new FeedEntry(), "tag2");
+        final ArrayList<FeedEntryTag> tags = Lists.newArrayList(tag1, tag2);
+
+        // Act
+        final Set<String> result = underTest.getTagNames(tags);
+
+        // Assert
+        assertEquals("tag1", result.toArray()[0]);
+    }
+
+    @Test
+    public void getRemoveList() {
+        // Arrange
+        final FeedEntryTag tag1 = new FeedEntryTag(new User(), new FeedEntry(), "tag1");
+        final FeedEntryTag tag2 = new FeedEntryTag(new User(), new FeedEntry(), "tag2");
+        final FeedEntryTag tag3 = new FeedEntryTag(new User(), new FeedEntry(), "tag3");
+        final FeedEntryTag tag4 = new FeedEntryTag(new User(), new FeedEntry(), "tag4");
+        final ArrayList<FeedEntryTag> existingTags = Lists.newArrayList(tag1, tag2, tag3, tag4);
+        final ArrayList<String> tagNames = Lists.newArrayList("tag1", "tag3");
+
+        // Act
+        final List<FeedEntryTag> result = underTest.getRemoveList(existingTags, tagNames);
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("tag2", result.get(0).getName());
+        assertEquals("tag4", result.get(1).getName());
+    }
+
+    @Test
+    public void getAddList() {
+        // Arrange
+        final User user = new User();
+        final FeedEntry entry = new FeedEntry();
+        final ArrayList<String> tagNames = Lists.newArrayList("tag1", "tag2", "tag3");
+        final HashSet<String> existingTagNames = Sets.newHashSet("tag2", "tag3");
+
+        // Act
+        final List<FeedEntryTag> result = underTest.getAddList(user, entry, tagNames, existingTagNames);
+
+        // Assert
+        assertEquals(1, result.size());
+        assertEquals(user, result.get(0).getUser());
+        assertEquals(entry, result.get(0).getEntry());
+        assertEquals("tag1", result.get(0).getName());
+    }
+}


### PR DESCRIPTION
I've refactored the `FeedEntryTagService` and added tests.

The behavior of the service is the same as before. I've just extracted some methods to make the code more readable/describable. So if the refactoring is not desired, the tests are working nevertheless (the tests for the extracted methods must be removed first).