### PR TITLE
Fix for illegal reflective access operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 		<dropwizard.version>1.3.20</dropwizard.version>
-		<guice.version>4.2.2</guice.version>
+		<guice.version>4.2.3</guice.version>
 		<querydsl.version>4.2.1</querydsl.version>
 		<rome.version>1.5.0</rome.version>
 	</properties>
@@ -480,7 +480,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.0.11-beta</version>
+			<version>3.6.28</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Updated `mockito-core` and `guice` to fix the following warnings:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection (file:.../.m2/repository/net/bytebuddy/byte-buddy/0.6.8/byte-buddy-0.6.8.jar) to method java.lang.ClassLoader.findLoadedClass(java.lang.String)
WARNING: Please consider reporting this to the maintainers of net.bytebuddy.dynamic.loading.ClassInjector$UsingReflection
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:.../.m2/repository/com/google/inject/guice/4.2.2/guice-4.2.2.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
