### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/src/main/java/com/commafeed/backend/feed/FeedRefreshUpdater.java
+++ b/src/main/java/com/commafeed/backend/feed/FeedRefreshUpdater.java
@@ -189,6 +189,7 @@ public class FeedRefreshUpdater implements Managed {
 			}
 		} catch (InterruptedException e) {
 			log.error("interrupted while waiting for lock for " + feed.getUrl() + " : " + e.getMessage(), e);
+			Thread.currentThread().interrupt();
 		} finally {
 			if (locked1) {
 				lock1.unlock();
@@ -214,6 +215,7 @@ public class FeedRefreshUpdater implements Managed {
 							Thread.sleep(30000);
 						} catch (InterruptedException e1) {
 							// do nothing
+							Thread.currentThread().interrupt();
 						}
 
 						pubSubService.subscribe(feed);


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).