### PR TITLE
Invalid migration in db.changelog-2.6.xml

### DIFF
--- a/src/main/resources/changelogs/db.changelog-2.6.xml
+++ b/src/main/resources/changelogs/db.changelog-2.6.xml
@@ -24,7 +24,7 @@
 	</changeSet>
 
 	<changeSet id="rename-filter-avoid-keyword" author="athou">
-		<renameColumn tableName="FEEDSUBSCRIPTIONS" oldColumnName="filter" newColumnName="filtering_expression" />
+		<renameColumn tableName="FEEDSUBSCRIPTIONS" oldColumnName="filter" newColumnName="filtering_expression" columnDataType="VARCHAR(4096)" />
 	</changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
Fix migration for mysql/mariadb environments missing columnDataType on renameColumn