### PR TITLE
Determine build directory from variable instead of hardcoding it.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 								<location>com.commafeed.frontend.model</location>
 								<location>com.commafeed.frontend.model.request</location>
 							</locations>
-							<swaggerDirectory>target/swagger</swaggerDirectory>
+							<swaggerDirectory>${project.build.directory}/swagger</swaggerDirectory>
 							<basePath>/rest</basePath>
 							<info>
 								<title>CommaFeed</title>


### PR DESCRIPTION
If target is a hardcoded path, then commands like `mvn -f ../ clean package` place the generated `swagger.json` in the current working directory instead of the target directory of the referenced project. I ran into this because I invoked `mvn` from a different directory while preparing a container image.