### PR TITLE
Allow API key for count of unread

### DIFF
--- a/commafeed-server/src/main/java/com/commafeed/frontend/resource/CategoryREST.java
+++ b/commafeed-server/src/main/java/com/commafeed/frontend/resource/CategoryREST.java
@@ -413,7 +413,7 @@ public class CategoryREST {
 	@UnitOfWork
 	@ApiOperation(value = "Get unread count for feed subscriptions", response = UnreadCount.class, responseContainer = "List")
 	@Timed
-	public Response getUnreadCount(@ApiParam(hidden = true) @SecurityCheck User user) {
+	public Response getUnreadCount(@ApiParam(hidden = true) @SecurityCheck(apiKeyAllowed = true) User user) {
 		Map<Long, UnreadCount> unreadCount = feedSubscriptionService.getUnreadCount(user);
 		return Response.ok(Lists.newArrayList(unreadCount.values())).build();
 	}


### PR DESCRIPTION
The only other functional alternative for me is to store the credentials as plain text what is obviously a horrible idea, thus my request to allow getting unread count through API key too since it won't really expose any critical information anyway.