### PR TITLE
Fix bug with Safari

### DIFF
--- a/commafeed-client/src/main.css
+++ b/commafeed-client/src/main.css
@@ -2,3 +2,8 @@ html, body {
     /* disable pull-to-refresh on mobile as it messes with vertical scrolling */
     overscroll-behavior: none;
 }
+
+#root {
+    height: 100vh;
+    overflow: auto;
+}


### PR DESCRIPTION
This PR fixes #1168 by allowing the root element to be scrollable. Simple fix, just let `#root` overflow as needed and things seem to work fine.

Tested on macOS Safari as well as iPhone Safari.

Caused by

```css
html,
body {
  overscroll-behavior: none;
}
```

in `/commafeed-client/src/main.css`. Bug only occurs when the sidebar is scrollable.
