### PR TITLE
login page: don't autocapitalize the username input

### DIFF
--- a/commafeed-client/src/pages/auth/LoginPage.tsx
+++ b/commafeed-client/src/pages/auth/LoginPage.tsx
@@ -50,6 +50,7 @@ export function LoginPage() {
                             }
                             size="md"
                             required
+                            autoCapitalize="off"
                         />
                         <PasswordInput
                             label={<Trans>Password</Trans>}


### PR DESCRIPTION
Small fix, just noticed it when testing on mobile