### PR TITLE
don't throw NotModifiedException on etag/lm changes

### DIFF
--- a/commafeed-server/src/main/java/com/commafeed/backend/HttpGetter.java
+++ b/commafeed-server/src/main/java/com/commafeed/backend/HttpGetter.java
@@ -139,14 +139,7 @@ public class HttpGetter {
 		}
 
 		String lastModifiedHeader = response.getLastModifiedHeader();
-		if (lastModifiedHeader != null && lastModifiedHeader.equals(request.getLastModified())) {
-			throw new NotModifiedException("lastModifiedHeader is the same");
-		}
-
 		String eTagHeader = response.getETagHeader();
-		if (eTagHeader != null && eTagHeader.equals(request.getETag())) {
-			throw new NotModifiedException("eTagHeader is the same");
-		}
 
 		Duration validFor = Optional.ofNullable(response.getCacheControl())
 				.filter(cc -> cc.getMaxAge() >= 0)


### PR DESCRIPTION
This is a suggestion for fixing #1746.

A well-behaved server should return 304 if our If-Modified-Since and If-None-Match indicate that we don't have the latest version of a resource cached. Having these extra conditions where we consider our local version fresh is not necessary, and may in fact lead to resource updates being missed when only one header changes.

We should instead trust the server to know whether it needs to send us a new resource or not based on the cache headers we provide.