### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,5 +1,8 @@
 name: SonarQube
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Athou/commafeed/security/code-scanning/26](https://github.com/Athou/commafeed/security/code-scanning/26)

To fix the issue, we will add the `permissions` key to the workflow to explicitly define the least privileges required for the job. Based on the workflow's functionality:
- It checks out code (`contents: read`).
- It runs tests and SonarQube analysis, which does not require write permissions.

We will set `contents: read` at the workflow level to restrict repository access to read-only. This ensures the workflow adheres to the principle of least privilege while avoiding unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
