### PR TITLE
chore: Switch to GraalVM 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  JAVA_VERSION: 21
+  JAVA_VERSION: 25
   DOCKER_BUILD_SUMMARY: false
 
 jobs:


### PR DESCRIPTION
JDK 25 is the new LTS after 21.

Tested on my instance, works perfectly.