### PR TITLE
Add SVG favicon option

### DIFF
--- a/commafeed-client/index.html
+++ b/commafeed-client/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link rel="manifest" href="manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />

--- a/commafeed-client/public/favicon.svg
+++ b/commafeed-client/public/favicon.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="393.84613"
+   width="393.84613"
+   viewBox="0 0 5.0480766 5.0480766"
+   version="1.1"
+   id="svg3"
+   sodipodi:docname="favicon.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="namedview3"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.21875"
+     inkscape:cx="207.17949"
+     inkscape:cy="187.07692"
+     inkscape:window-width="1440"
+     inkscape:window-height="855"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3" />
+  <rect
+     fill="#f88a14"
+     rx="0.53846151"
+     ry="0.53846151"
+     height="5.0480766"
+     width="5.0480766"
+     id="rect1"
+     x="0"
+     y="0"
+     style="stroke-width:0.769231" />
+  <path
+     d="m 1.3450904,0.64548657 c 2.9002,0 2.9002,2.91010003 2.9002,2.91010003"
+     fill="none"
+     stroke="#ffffff"
+     stroke-linecap="round"
+     stroke-width="0.78125"
+     id="path1" />
+  <path
+     d="m 1.3377904,1.9915866 c 1.5705,-0.00908 1.5705,1.5639 1.5705,1.5639"
+     fill="none"
+     stroke="#ffffff"
+     stroke-linecap="round"
+     stroke-width="0.78125"
+     id="path2" />
+  <path
+     d="m 2.0192904,3.5227866 c 0,0.23366 -0.10712,0.47418 -0.24663,0.6537 -0.1814,0.2333 -0.5705,0.5618 -0.6913,0.5653 0.0402,-0.0662 0.263,-0.5654 0.2563,-0.5654 -0.36423004,0 -0.65950004,-0.29265 -0.65950004,-0.65365 0,-0.361 0.29527,-0.65365 0.65950004,-0.65365 0.36423,0 0.68159,0.29265 0.68159,0.65365 z"
+     fill="#ffffff"
+     id="path3" />
+</svg>


### PR DESCRIPTION
The existing 16x16 pixel favicon looks a bit pixelated. This adds an SVG favicon option based on the existing SVG logo file but cropped tight similar to the existing favicon. That makes it nice and crisp.

Before (on my setup, Firefox 145, 13" 2.8k screen at 200 % scaling):

<img width="478" height="98" alt="Screenshot From 2025-11-29 15-06-51" src="https://github.com/user-attachments/assets/e986f8fd-18e9-4c81-a7be-dd5be4d89f5a" />

After:

<img width="478" height="98" alt="Screenshot From 2025-11-29 15-07-02" src="https://github.com/user-attachments/assets/c086c699-ab95-461c-955d-4f6015a42bfe" />
