### PR TITLE
Highlight article titles matching a per-feed expression

### DIFF
--- a/commafeed-client/src/app/types.ts
+++ b/commafeed-client/src/app/types.ts
@@ -28,6 +28,7 @@ export interface Subscription {
     position: number
     newestItemTime?: number
     filter?: string
+    highlightExpression?: string
     filterLegacy?: string
     pushNotificationsEnabled: boolean
     autoMarkAsReadAfterDays?: number
@@ -81,6 +82,7 @@ export interface Entry {
     read: boolean
     starred: boolean
     markable: boolean
+    highlighted?: boolean
     tags: string[]
 }
 
@@ -112,6 +114,7 @@ export interface FeedModificationRequest {
     categoryId?: string
     position?: number
     filter?: string
+    highlightExpression?: string
     pushNotificationsEnabled: boolean
     autoMarkAsReadAfterDays?: number
 }

--- a/commafeed-client/src/components/content/header/FeedEntryTitle.tsx
+++ b/commafeed-client/src/components/content/header/FeedEntryTitle.tsx
@@ -11,20 +11,27 @@ const useStyles = tss.create(() => ({
     content: {
         textWrap: "inherit",
     },
+    highlighted: {
+        backgroundColor: "var(--mantine-color-yellow-light)",
+        borderRadius: "var(--mantine-radius-xs)",
+        boxDecorationBreak: "clone",
+        fontWeight: 600,
+        paddingInline: 4,
+    },
 }))
 
 export function FeedEntryTitle(props: Readonly<FeedEntryTitleProps>) {
     const search = useAppSelector(state => state.entries.search)
     const keywords = search?.split(" ")
 
-    const { classes } = useStyles()
+    const { classes, cx } = useStyles()
     return (
         <Highlight
             inherit
             highlight={keywords ?? ""}
             // make sure ellipsis is shown when title is too long
             span
-            className={classes.content}
+            className={cx(classes.content, { [classes.highlighted]: props.entry.highlighted })}
         >
             {props.entry.title}
         </Highlight>

--- a/commafeed-client/src/pages/app/FeedDetailsPage.tsx
+++ b/commafeed-client/src/pages/app/FeedDetailsPage.tsx
@@ -82,7 +82,11 @@ export function FeedDetailsPage() {
 
     useEffect(() => {
         if (!feed) return
-        setValues(feed)
+        setValues({
+            ...feed,
+            filter: feed.filter ?? "",
+            highlightExpression: feed.highlightExpression ?? "",
+        })
     }, [setValues, feed])
 
     if (!feed) return <Loader />
@@ -174,6 +178,21 @@ export function FeedDetailsPage() {
                         )}
                         <Box mt="xs">
                             <FilteringExpressionEditor initialValue={feed.filter} onChange={value => form.setFieldValue("filter", value)} />
+                        </Box>
+                    </Input.Wrapper>
+                    <Input.Wrapper
+                        label={<Trans>Highlighting expression</Trans>}
+                        description={
+                            <Trans>
+                                Build an expression to highlight matching entry titles. Matching titles are styled but never marked as read.
+                            </Trans>
+                        }
+                    >
+                        <Box mt="xs">
+                            <FilteringExpressionEditor
+                                initialValue={feed.highlightExpression}
+                                onChange={value => form.setFieldValue("highlightExpression", value)}
+                            />
                         </Box>
                     </Input.Wrapper>
 

--- a/commafeed-server/src/main/java/com/commafeed/backend/model/FeedSubscription.java
+++ b/commafeed-server/src/main/java/com/commafeed/backend/model/FeedSubscription.java
@@ -43,6 +43,9 @@ public class FeedSubscription extends AbstractModel {
 	@Column(name = "filtering_expression", length = 4096)
 	private String filter;
 
+	@Column(name = "highlight_expression", length = 4096)
+	private String highlightExpression;
+
 	@Column(name = "filtering_expression_legacy", length = 4096)
 	private String filterLegacy;
 

--- a/commafeed-server/src/main/java/com/commafeed/frontend/model/Entry.java
+++ b/commafeed-server/src/main/java/com/commafeed/frontend/model/Entry.java
@@ -96,6 +96,9 @@ public class Entry implements Serializable {
 	@Schema(description = "whether the entry is still markable (old entry statuses are discarded)", required = true)
 	private boolean markable;
 
+	@Schema(description = "whether the entry title should be highlighted", required = true)
+	private boolean highlighted;
+
 	@Schema(description = "tags", required = true)
 	private List<String> tags;
 

--- a/commafeed-server/src/main/java/com/commafeed/frontend/model/Subscription.java
+++ b/commafeed-server/src/main/java/com/commafeed/frontend/model/Subscription.java
@@ -62,6 +62,9 @@ public class Subscription implements Serializable {
 	@Schema(description = "CEL string evaluated on new entries to mark them as read if they do not match")
 	private String filter;
 
+	@Schema(description = "CEL string evaluated on new entries to highlight matching titles (cosmetic, never marks read)")
+	private String highlightExpression;
+
 	@Schema(description = "JEXL legacy filter")
 	private String filterLegacy;
 
@@ -90,6 +93,7 @@ public class Subscription implements Serializable {
 		sub.setNewestItemTime(unreadCount.getNewestItemTime());
 		sub.setCategoryId(category == null ? null : String.valueOf(category.getId()));
 		sub.setFilter(subscription.getFilter());
+		sub.setHighlightExpression(subscription.getHighlightExpression());
 		sub.setFilterLegacy(subscription.getFilterLegacy());
 		sub.setPushNotificationsEnabled(subscription.isPushNotificationsEnabled());
 		sub.setAutoMarkAsReadAfterDays(subscription.getAutoMarkAsReadAfterDays());

--- a/commafeed-server/src/main/java/com/commafeed/frontend/model/request/FeedModificationRequest.java
+++ b/commafeed-server/src/main/java/com/commafeed/frontend/model/request/FeedModificationRequest.java
@@ -31,6 +31,10 @@ public class FeedModificationRequest implements Serializable {
 	@Size(max = 4096)
 	private String filter;
 
+	@Schema(description = "CEL string evaluated on new entries to highlight matching titles (cosmetic, never marks read)")
+	@Size(max = 4096)
+	private String highlightExpression;
+
 	@Schema(description = "whether to send push notifications for new entries of this feed")
 	private boolean pushNotificationsEnabled;
 

--- a/commafeed-server/src/main/java/com/commafeed/frontend/resource/CategoryREST.java
+++ b/commafeed-server/src/main/java/com/commafeed/frontend/resource/CategoryREST.java
@@ -48,6 +48,8 @@ import com.commafeed.backend.model.FeedSubscription;
 import com.commafeed.backend.model.User;
 import com.commafeed.backend.model.UserSettings.ReadingMode;
 import com.commafeed.backend.model.UserSettings.ReadingOrder;
+import com.commafeed.backend.service.FeedEntryFilteringService;
+import com.commafeed.backend.service.FeedEntryFilteringService.FeedEntryFilterException;
 import com.commafeed.backend.service.FeedEntryService;
 import com.commafeed.backend.service.FeedSubscriptionService;
 import com.commafeed.frontend.model.Category;
@@ -93,6 +95,7 @@ public class CategoryREST {
 	private final FeedCategoryDAO feedCategoryDAO;
 	private final FeedEntryStatusDAO feedEntryStatusDAO;
 	private final FeedSubscriptionDAO feedSubscriptionDAO;
+	private final FeedEntryFilteringService feedEntryFilteringService;
 	private final FeedEntryService feedEntryService;
 	private final FeedSubscriptionService feedSubscriptionService;
 	private final CommaFeedConfiguration config;
@@ -153,14 +156,14 @@ public class CategoryREST {
 					offset, limit + 1, order, true, tag, null, null);
 
 			for (FeedEntryStatus status : list) {
-				entries.getEntries().add(Entry.build(status, config.imageProxyEnabled()));
+				entries.getEntries().add(buildEntry(status));
 			}
 
 		} else if (STARRED.equals(id)) {
 			entries.setName("Starred");
 			List<FeedEntryStatus> starred = feedEntryStatusDAO.findStarred(user, newerThanDate, offset, limit + 1, order, true);
 			for (FeedEntryStatus status : starred) {
-				entries.getEntries().add(Entry.build(status, config.imageProxyEnabled()));
+				entries.getEntries().add(buildEntry(status));
 			}
 		} else {
 			FeedCategory parent = feedCategoryDAO.findById(user, Long.valueOf(id));
@@ -172,7 +175,7 @@ public class CategoryREST {
 						offset, limit + 1, order, true, tag, null, null);
 
 				for (FeedEntryStatus status : list) {
-					entries.getEntries().add(Entry.build(status, config.imageProxyEnabled()));
+					entries.getEntries().add(buildEntry(status));
 				}
 				entries.setName(parent.getName());
 			} else {
@@ -189,6 +192,19 @@ public class CategoryREST {
 		entries.setTimestamp(System.currentTimeMillis());
 		entries.setIgnoredReadStatus(STARRED.equals(id) || keywords != null || tag != null);
 		return Response.ok(entries).build();
+	}
+
+	private Entry buildEntry(FeedEntryStatus status) {
+		Entry entry = Entry.build(status, config.imageProxyEnabled());
+		String highlightExpression = status.getSubscription().getHighlightExpression();
+		if (StringUtils.isNotBlank(highlightExpression)) {
+			try {
+				entry.setHighlighted(feedEntryFilteringService.filterMatchesEntry(highlightExpression, status.getEntry()));
+			} catch (FeedEntryFilterException e) {
+				log.warn("Could not evaluate highlight expression for subscription {}", status.getSubscription().getId(), e);
+			}
+		}
+		return entry;
 	}
 
 	@Path("/entriesAsFeed")

--- a/commafeed-server/src/main/java/com/commafeed/frontend/resource/FeedREST.java
+++ b/commafeed-server/src/main/java/com/commafeed/frontend/resource/FeedREST.java
@@ -173,7 +173,7 @@ public class FeedREST {
 					entryKeywords, newerThanDate, offset, limit + 1, order, true, null, null, null);
 
 			for (FeedEntryStatus status : list) {
-				entries.getEntries().add(Entry.build(status, config.imageProxyEnabled()));
+				entries.getEntries().add(buildEntry(status));
 			}
 
 			boolean hasMore = entries.getEntries().size() > limit;
@@ -408,6 +408,19 @@ public class FeedREST {
 		return url;
 	}
 
+	private Entry buildEntry(FeedEntryStatus status) {
+		Entry entry = Entry.build(status, config.imageProxyEnabled());
+		String highlightExpression = status.getSubscription().getHighlightExpression();
+		if (StringUtils.isNotBlank(highlightExpression)) {
+			try {
+				entry.setHighlighted(feedEntryFilteringService.filterMatchesEntry(highlightExpression, status.getEntry()));
+			} catch (FeedEntryFilterException e) {
+				log.warn("Could not evaluate highlight expression for subscription {}", status.getSubscription().getId(), e);
+			}
+		}
+		return entry;
+	}
+
 	@POST
 	@Path("/unsubscribe")
 	@Transactional
@@ -435,6 +448,7 @@ public class FeedREST {
 
 		try {
 			feedEntryFilteringService.filterMatchesEntry(req.getFilter(), TEST_ENTRY);
+			feedEntryFilteringService.filterMatchesEntry(req.getHighlightExpression(), TEST_ENTRY);
 		} catch (FeedEntryFilterException e) {
 			return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).type(MediaType.TEXT_PLAIN).build();
 		}
@@ -443,6 +457,7 @@ public class FeedREST {
 		FeedSubscription subscription = feedSubscriptionDAO.findById(user, req.getId());
 
 		subscription.setFilter(req.getFilter());
+		subscription.setHighlightExpression(req.getHighlightExpression());
 		if (StringUtils.isNotBlank(subscription.getFilter())) {
 			// if the new filter is filled, remove the legacy filter
 			subscription.setFilterLegacy(null);

--- a/commafeed-server/src/main/resources/changelogs/db.changelog-highlight.xml
+++ b/commafeed-server/src/main/resources/changelogs/db.changelog-highlight.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+				   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+	<changeSet id="add-highlight-expression" author="commafeed">
+		<addColumn tableName="FEEDSUBSCRIPTIONS">
+			<column name="highlight_expression" type="VARCHAR(4096)">
+				<constraints nullable="true" />
+			</column>
+		</addColumn>
+	</changeSet>
+
+</databaseChangeLog>

--- a/commafeed-server/src/main/resources/migrations.xml
+++ b/commafeed-server/src/main/resources/migrations.xml
@@ -39,5 +39,6 @@
 	<include file="changelogs/db.changelog-5.12.xml" />
 	<include file="changelogs/db.changelog-7.0.xml" />
 	<include file="changelogs/db.changelog-7.2.xml" />
+	<include file="changelogs/db.changelog-highlight.xml" />
 
-</databaseChangeLog> 
+</databaseChangeLog>

--- a/commafeed-server/src/test/java/com/commafeed/backend/service/FeedEntryFilteringServiceTest.java
+++ b/commafeed-server/src/test/java/com/commafeed/backend/service/FeedEntryFilteringServiceTest.java
@@ -69,6 +69,12 @@ class FeedEntryFilteringServiceTest {
 	}
 
 	@Test
+	void highlightTitleExpressionMatchesTitle() throws FeedEntryFilterException {
+		Assertions.assertTrue(service.filterMatchesEntry("title.contains(\"pull request\")", entry));
+		Assertions.assertFalse(service.filterMatchesEntry("title.contains(\"release notes\")", entry));
+	}
+
+	@Test
 	void urlContainsExpression() throws FeedEntryFilterException {
 		Assertions.assertTrue(service.filterMatchesEntry("url.contains(\"github\")", entry));
 	}


### PR DESCRIPTION
## Summary

Adds a per-feed highlighting expression. You can now give a feed a CEL expression that highlights matching entry titles in the list, without changing what gets marked as read. This is the spotlight-style behavior requested in #2126, scoped to titles and per-feed as suggested.

## Why this matters

Filtering already lets you hide entries that do not match an expression, but there was no way to keep everything visible and just call attention to the entries you care about. Highlighting reuses the same expression syntax for a purely cosmetic effect. See #2126.

## Changes

- New `highlight_expression` column on `FEEDSUBSCRIPTIONS` (Liquibase changelog `db.changelog-highlight.xml`, registered in `migrations.xml`).
- `highlightExpression` added to `FeedSubscription`, `FeedModificationRequest`, and the `Subscription` read model so it persists and round-trips through `/feed/modify`. The expression is validated on save the same way the filter is.
- New `highlighted` boolean on the `Entry` REST model. It is computed at display time in `FeedREST` and `CategoryREST` by evaluating the subscription's highlight expression with the existing `FeedEntryFilteringService`. Highlight evaluation never persists a status and never marks an entry read.
- Frontend: a second expression editor on the feed details page for the highlight expression, matching `highlightExpression`/`highlighted` types, and a highlight style applied to the entry title when `highlighted` is true.

## Testing

- `FeedEntryFilteringServiceTest`: added a case asserting a title-matching highlight expression returns true and a non-matching one returns false.
- `mvn -pl commafeed-server -am compile` and `npm --prefix commafeed-client run build` both pass.

Fixes #2126

AI was used for assistance.
