### PR TITLE
Translate login authentication errors

### DIFF
--- a/commafeed-client/src/app/client.test.ts
+++ b/commafeed-client/src/app/client.test.ts
@@ -1,0 +1,23 @@
+import type { AxiosError } from "axios"
+import { describe, expect, it } from "vitest"
+import { loginErrorToStrings } from "./client"
+
+const axiosError = (status: number, data: unknown) =>
+    ({
+        isAxiosError: true,
+        response: { status, data },
+    }) as AxiosError
+
+describe("loginErrorToStrings", () => {
+    it("uses the translated message for authentication errors", () => {
+        const error = axiosError(401, { message: "wrong username or password" })
+
+        expect(loginErrorToStrings(error, "Translated authentication error")).toEqual(["Translated authentication error"])
+    })
+
+    it("preserves backend messages for unexpected errors", () => {
+        const error = axiosError(500, { message: "unexpected error" })
+
+        expect(loginErrorToStrings(error, "Translated authentication error")).toEqual(["unexpected error"])
+    })
+})

--- a/commafeed-client/src/app/client.test.ts
+++ b/commafeed-client/src/app/client.test.ts
@@ -1,6 +1,7 @@
+import { i18n } from "@lingui/core"
 import type { AxiosError } from "axios"
-import { describe, expect, it } from "vitest"
-import { loginErrorToStrings } from "./client"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { errorToStrings } from "./client"
 
 const axiosError = (status: number, data: unknown) =>
     ({
@@ -8,16 +9,28 @@ const axiosError = (status: number, data: unknown) =>
         response: { status, data },
     }) as AxiosError
 
-describe("loginErrorToStrings", () => {
-    it("uses the translated message for authentication errors", () => {
-        const error = axiosError(401, { message: "wrong username or password" })
+describe("errorToStrings", () => {
+    afterEach(() => vi.restoreAllMocks())
 
-        expect(loginErrorToStrings(error, "Translated authentication error")).toEqual(["Translated authentication error"])
+    it("translates known application error types", () => {
+        vi.spyOn(i18n, "_").mockReturnValue("Translated authentication error")
+        const error = axiosError(401, {
+            type: "WRONG_USERNAME_OR_PASSWORD",
+            message: "wrong username or password",
+        })
+
+        expect(errorToStrings(error)).toEqual(["Translated authentication error"])
     })
 
     it("preserves backend messages for unexpected errors", () => {
         const error = axiosError(500, { message: "unexpected error" })
 
-        expect(loginErrorToStrings(error, "Translated authentication error")).toEqual(["unexpected error"])
+        expect(errorToStrings(error)).toEqual(["unexpected error"])
+    })
+
+    it("preserves backend messages for unknown application error types", () => {
+        const error = axiosError(400, { type: "UNKNOWN_ERROR", message: "unknown error" })
+
+        expect(errorToStrings(error)).toEqual(["unknown error"])
     })
 })

--- a/commafeed-client/src/app/client.ts
+++ b/commafeed-client/src/app/client.ts
@@ -136,6 +136,15 @@ export const errorToStrings = (err: unknown) => {
     return strings
 }
 
+/**
+ * Transform a login error into messages that can be displayed to the user.
+ * Authentication failures use a client-provided message so it can be translated.
+ */
+export const loginErrorToStrings = (err: unknown, authenticationErrorMessage: string) => {
+    if (isAuthenticationError(err)) return [authenticationErrorMessage]
+    return errorToStrings(err)
+}
+
 function isMessageError(err: AxiosError): err is AxiosError<{ message: string }> {
     return !!err.response && !!err.response.data && typeof err.response.data === "object" && "message" in err.response.data
 }

--- a/commafeed-client/src/app/client.ts
+++ b/commafeed-client/src/app/client.ts
@@ -1,3 +1,5 @@
+import { i18n, type MessageDescriptor } from "@lingui/core"
+import { msg } from "@lingui/core/macro"
 import axios, { type AxiosError } from "axios"
 import type {
     AddCategoryRequest,
@@ -6,6 +8,8 @@ import type {
     Category,
     CategoryModificationRequest,
     CollapseRequest,
+    CommaFeedApplicationError,
+    CommaFeedExceptionType,
     Entries,
     FeedInfo,
     FeedInfoRequest,
@@ -30,6 +34,10 @@ import type {
     TagRequest,
     UserModel,
 } from "./types"
+
+const applicationErrorMessages = {
+    WRONG_USERNAME_OR_PASSWORD: msg`Wrong username or password`,
+} satisfies Record<CommaFeedExceptionType, MessageDescriptor>
 
 const axiosInstance = axios.create({ baseURL: "./rest", withCredentials: true })
 axiosInstance.interceptors.response.use(
@@ -128,21 +136,23 @@ export const errorToStrings = (err: unknown) => {
     let strings: string[] = []
 
     if (axios.isAxiosError(err) && err.response) {
-        if (typeof err.response.data === "string") strings.push(err.response.data)
-        if (isMessageError(err)) strings.push(err.response.data.message)
-        if (isMessageArrayError(err)) strings = [...strings, ...err.response.data.errors]
+        if (isCommaFeedApplicationError(err)) {
+            strings.push(i18n._(applicationErrorMessages[err.response.data.type]))
+        } else {
+            if (typeof err.response.data === "string") strings.push(err.response.data)
+            if (isMessageError(err)) strings.push(err.response.data.message)
+            if (isMessageArrayError(err)) strings = [...strings, ...err.response.data.errors]
+        }
     }
 
     return strings
 }
 
-/**
- * Transform a login error into messages that can be displayed to the user.
- * Authentication failures use a client-provided message so it can be translated.
- */
-export const loginErrorToStrings = (err: unknown, authenticationErrorMessage: string) => {
-    if (isAuthenticationError(err)) return [authenticationErrorMessage]
-    return errorToStrings(err)
+function isCommaFeedApplicationError(err: AxiosError): err is AxiosError<CommaFeedApplicationError> {
+    const data = err.response?.data
+    if (!data || typeof data !== "object" || !("type" in data)) return false
+    const type = data.type
+    return typeof type === "string" && Object.hasOwn(applicationErrorMessages, type)
 }
 
 function isMessageError(err: AxiosError): err is AxiosError<{ message: string }> {

--- a/commafeed-client/src/app/types.ts
+++ b/commafeed-client/src/app/types.ts
@@ -338,3 +338,10 @@ export interface AuthenticationError {
     message: string
     allowRegistrations: boolean
 }
+
+export type CommaFeedExceptionType = "WRONG_USERNAME_OR_PASSWORD"
+
+export interface CommaFeedApplicationError {
+    type: CommaFeedExceptionType
+    message: string
+}

--- a/commafeed-client/src/locales/ar/messages.po
+++ b/commafeed-client/src/locales/ar/messages.po
@@ -1150,6 +1150,11 @@ msgstr "موقع الكتروني"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "مرحباً! يبدو أن هذه هي المرة الأولى التي تقوم فيها بتشغيل CommaFeed. يرجى إنشاء حساب مسؤول للبدء."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "أصفر"

--- a/commafeed-client/src/locales/ar/messages.po
+++ b/commafeed-client/src/locales/ar/messages.po
@@ -1150,8 +1150,7 @@ msgstr "موقع الكتروني"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "مرحباً! يبدو أن هذه هي المرة الأولى التي تقوم فيها بتشغيل CommaFeed. يرجى إنشاء حساب مسؤول للبدء."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/ca/messages.po
+++ b/commafeed-client/src/locales/ca/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Lloc web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Benvingut! Sembla que aquesta és la primera vegada que executeu CommaFeed. Creeu un compte d'administrador per començar."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/ca/messages.po
+++ b/commafeed-client/src/locales/ca/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Lloc web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Benvingut! Sembla que aquesta és la primera vegada que executeu CommaFeed. Creeu un compte d'administrador per començar."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Groc"

--- a/commafeed-client/src/locales/cs/messages.po
+++ b/commafeed-client/src/locales/cs/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Webová stránka"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Vítejte! Zdá se, že je to poprvé, co spouštíte CommaFeed. Chcete-li začít, vytvořte si účet správce."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Žlutá"

--- a/commafeed-client/src/locales/cs/messages.po
+++ b/commafeed-client/src/locales/cs/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Webová stránka"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Vítejte! Zdá se, že je to poprvé, co spouštíte CommaFeed. Chcete-li začít, vytvořte si účet správce."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/cy/messages.po
+++ b/commafeed-client/src/locales/cy/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Gwefan"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Croeso! Ymddengys mai dyma'r tro cyntaf i chi redeg CommaFeed. Creuwch gyfrif gweinyddwr i ddechrau."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Melyn"

--- a/commafeed-client/src/locales/cy/messages.po
+++ b/commafeed-client/src/locales/cy/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Gwefan"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Croeso! Ymddengys mai dyma'r tro cyntaf i chi redeg CommaFeed. Creuwch gyfrif gweinyddwr i ddechrau."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/da/messages.po
+++ b/commafeed-client/src/locales/da/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Hjemmeside"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Velkommen! Det ser ud til at være første gang, du kører CommaFeed. Opret venligst en administratorkonto for at komme i gang."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/da/messages.po
+++ b/commafeed-client/src/locales/da/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Hjemmeside"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Velkommen! Det ser ud til at være første gang, du kører CommaFeed. Opret venligst en administratorkonto for at komme i gang."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Gul"

--- a/commafeed-client/src/locales/de/messages.po
+++ b/commafeed-client/src/locales/de/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Webseite"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Willkommen! Dies scheint das erste Mal zu sein, dass Sie CommaFeed ausführen. Bitte erstellen Sie ein Administrator-Konto, um zu beginnen."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Gelb"

--- a/commafeed-client/src/locales/de/messages.po
+++ b/commafeed-client/src/locales/de/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Webseite"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Willkommen! Dies scheint das erste Mal zu sein, dass Sie CommaFeed ausführen. Bitte erstellen Sie ein Administrator-Konto, um zu beginnen."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/en/messages.po
+++ b/commafeed-client/src/locales/en/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Website"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr "Wrong username or password"
 

--- a/commafeed-client/src/locales/en/messages.po
+++ b/commafeed-client/src/locales/en/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Website"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr "Wrong username or password"
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Yellow"

--- a/commafeed-client/src/locales/es/messages.po
+++ b/commafeed-client/src/locales/es/messages.po
@@ -1151,6 +1151,11 @@ msgstr "Sitio web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "¡Bienvenido! Parece que esta es la primera vez que ejecutas CommaFeed. Por favor, crea una cuenta de administrador para empezar."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Amarillo"

--- a/commafeed-client/src/locales/es/messages.po
+++ b/commafeed-client/src/locales/es/messages.po
@@ -1151,8 +1151,7 @@ msgstr "Sitio web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "¡Bienvenido! Parece que esta es la primera vez que ejecutas CommaFeed. Por favor, crea una cuenta de administrador para empezar."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/fa/messages.po
+++ b/commafeed-client/src/locales/fa/messages.po
@@ -1150,8 +1150,7 @@ msgstr "وب سایت"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "خوش آمدید! به نظر می‌رسد این اولین بار است که CommaFeed را اجرا می‌کنید. لطفاً برای شروع یک حساب مدیر ایجاد کنید."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/fa/messages.po
+++ b/commafeed-client/src/locales/fa/messages.po
@@ -1150,6 +1150,11 @@ msgstr "وب سایت"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "خوش آمدید! به نظر می‌رسد این اولین بار است که CommaFeed را اجرا می‌کنید. لطفاً برای شروع یک حساب مدیر ایجاد کنید."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "زرد"

--- a/commafeed-client/src/locales/fi/messages.po
+++ b/commafeed-client/src/locales/fi/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Verkkosivusto"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Tervetuloa! Näyttää siltä, että suoritat CommaFeediä ensimmäistä kertaa. Luo ylläpitäjän tili aloittaaksesi."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Keltainen"

--- a/commafeed-client/src/locales/fi/messages.po
+++ b/commafeed-client/src/locales/fi/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Verkkosivusto"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Tervetuloa! Näyttää siltä, että suoritat CommaFeediä ensimmäistä kertaa. Luo ylläpitäjän tili aloittaaksesi."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/fr/messages.po
+++ b/commafeed-client/src/locales/fr/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Site web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Bienvenue ! Il semble que ce soit le premier démarrage de Commafeed. Avant tout, vous devez créer un compte administrateur."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Jaune"

--- a/commafeed-client/src/locales/fr/messages.po
+++ b/commafeed-client/src/locales/fr/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Site web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Bienvenue ! Il semble que ce soit le premier démarrage de Commafeed. Avant tout, vous devez créer un compte administrateur."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/gl/messages.po
+++ b/commafeed-client/src/locales/gl/messages.po
@@ -1151,8 +1151,7 @@ msgstr "Páxina web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Benvida! Semella que é a primeira vez que executas CommaFeed. Para comezar, crea unha conta de administración."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/gl/messages.po
+++ b/commafeed-client/src/locales/gl/messages.po
@@ -1151,6 +1151,11 @@ msgstr "Páxina web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Benvida! Semella que é a primeira vez que executas CommaFeed. Para comezar, crea unha conta de administración."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Amarelo"

--- a/commafeed-client/src/locales/hu/messages.po
+++ b/commafeed-client/src/locales/hu/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Webhely"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Üdvözöljük! Úgy tűnik, ez az első alkalom, hogy a CommaFeedet futtatja. Kérjük, hozzon létre egy rendszergazdai fiókot a kezdéshez."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Sárga"

--- a/commafeed-client/src/locales/hu/messages.po
+++ b/commafeed-client/src/locales/hu/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Webhely"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Üdvözöljük! Úgy tűnik, ez az első alkalom, hogy a CommaFeedet futtatja. Kérjük, hozzon létre egy rendszergazdai fiókot a kezdéshez."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/id/messages.po
+++ b/commafeed-client/src/locales/id/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Situs Web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Selamat datang! Ini sepertinya pertama kalinya Anda menjalankan CommaFeed. Silakan buat akun administrator untuk memulai."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Kuning"

--- a/commafeed-client/src/locales/id/messages.po
+++ b/commafeed-client/src/locales/id/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Situs Web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Selamat datang! Ini sepertinya pertama kalinya Anda menjalankan CommaFeed. Silakan buat akun administrator untuk memulai."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/it/messages.po
+++ b/commafeed-client/src/locales/it/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Sito web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Benvenuto! Sembra che sia la prima volta che esegui CommaFeed. Crea un account amministratore per iniziare."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/it/messages.po
+++ b/commafeed-client/src/locales/it/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Sito web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Benvenuto! Sembra che sia la prima volta che esegui CommaFeed. Crea un account amministratore per iniziare."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Giallo"

--- a/commafeed-client/src/locales/ja/messages.po
+++ b/commafeed-client/src/locales/ja/messages.po
@@ -1150,6 +1150,11 @@ msgstr "ウェブサイト"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "ようこそ！CommaFeedを初めて実行するようです。開始するには管理者アカウントを作成してください。"
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "イエロー"

--- a/commafeed-client/src/locales/ja/messages.po
+++ b/commafeed-client/src/locales/ja/messages.po
@@ -1150,8 +1150,7 @@ msgstr "ウェブサイト"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "ようこそ！CommaFeedを初めて実行するようです。開始するには管理者アカウントを作成してください。"
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/ko/messages.po
+++ b/commafeed-client/src/locales/ko/messages.po
@@ -1150,6 +1150,11 @@ msgstr "웹사이트"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "환영합니다! CommaFeed를 처음 실행하는 것 같습니다. 시작하려면 관리자 계정을 만드십시오."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "옐로우"

--- a/commafeed-client/src/locales/ko/messages.po
+++ b/commafeed-client/src/locales/ko/messages.po
@@ -1150,8 +1150,7 @@ msgstr "웹사이트"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "환영합니다! CommaFeed를 처음 실행하는 것 같습니다. 시작하려면 관리자 계정을 만드십시오."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/ms/messages.po
+++ b/commafeed-client/src/locales/ms/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Laman web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Selamat datang! Ini nampaknya kali pertama anda menjalankan CommaFeed. Sila cipta akaun pentadbir untuk bermula."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Kuning"

--- a/commafeed-client/src/locales/ms/messages.po
+++ b/commafeed-client/src/locales/ms/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Laman web"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Selamat datang! Ini nampaknya kali pertama anda menjalankan CommaFeed. Sila cipta akaun pentadbir untuk bermula."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/nb/messages.po
+++ b/commafeed-client/src/locales/nb/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Nettsted"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Velkommen! Det ser ut til å være første gang du kjører CommaFeed. Vennligst opprett en administratorkonto for å komme i gang."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/nb/messages.po
+++ b/commafeed-client/src/locales/nb/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Nettsted"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Velkommen! Det ser ut til å være første gang du kjører CommaFeed. Vennligst opprett en administratorkonto for å komme i gang."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Gul"

--- a/commafeed-client/src/locales/nl/messages.po
+++ b/commafeed-client/src/locales/nl/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Website"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Welkom! Dit lijkt de eerste keer te zijn dat je CommaFeed draait. Maak een beheerdersaccount aan om aan de slag te gaan."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/nl/messages.po
+++ b/commafeed-client/src/locales/nl/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Website"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Welkom! Dit lijkt de eerste keer te zijn dat je CommaFeed draait. Maak een beheerdersaccount aan om aan de slag te gaan."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Geel"

--- a/commafeed-client/src/locales/nn/messages.po
+++ b/commafeed-client/src/locales/nn/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Nettstad"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Velkomen! Det ser ut til å vera fyrste gongen du køyrer CommaFeed. Ver venleg og opprett ein administratorkonto for å koma i gang."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/nn/messages.po
+++ b/commafeed-client/src/locales/nn/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Nettstad"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Velkomen! Det ser ut til å vera fyrste gongen du køyrer CommaFeed. Ver venleg og opprett ein administratorkonto for å koma i gang."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Gul"

--- a/commafeed-client/src/locales/pl/messages.po
+++ b/commafeed-client/src/locales/pl/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Strona internetowa"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Witaj! Wygląda na to, że uruchamiasz CommaFeed po raz pierwszy. Aby rozpocząć, utwórz konto administratora."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/pl/messages.po
+++ b/commafeed-client/src/locales/pl/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Strona internetowa"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Witaj! Wygląda na to, że uruchamiasz CommaFeed po raz pierwszy. Aby rozpocząć, utwórz konto administratora."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Żółty"

--- a/commafeed-client/src/locales/pt/messages.po
+++ b/commafeed-client/src/locales/pt/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Site"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Bem-vindo! Esta parece ser a primeira vez que você está executando o CommaFeed. Crie uma conta de administrador para começar."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/pt/messages.po
+++ b/commafeed-client/src/locales/pt/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Site"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Bem-vindo! Esta parece ser a primeira vez que você está executando o CommaFeed. Crie uma conta de administrador para começar."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Amarelo"

--- a/commafeed-client/src/locales/ru/messages.po
+++ b/commafeed-client/src/locales/ru/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Веб-сайт"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Добро пожаловать! Похоже, вы запускаете CommaFeed в первый раз. Пожалуйста, создайте учетную запись администратора, чтобы начать работу."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/ru/messages.po
+++ b/commafeed-client/src/locales/ru/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Веб-сайт"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Добро пожаловать! Похоже, вы запускаете CommaFeed в первый раз. Пожалуйста, создайте учетную запись администратора, чтобы начать работу."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Желтый"

--- a/commafeed-client/src/locales/sk/messages.po
+++ b/commafeed-client/src/locales/sk/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Webová stránka"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Vitajte! Zdá sa, že CommaFeed spúšťate prvýkrát. Ak chcete začať, vytvorte si účet správcu."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/sk/messages.po
+++ b/commafeed-client/src/locales/sk/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Webová stránka"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Vitajte! Zdá sa, že CommaFeed spúšťate prvýkrát. Ak chcete začať, vytvorte si účet správcu."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Žltá"

--- a/commafeed-client/src/locales/sv/messages.po
+++ b/commafeed-client/src/locales/sv/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Webbplats"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Välkommen! Det verkar vara första gången du kör CommaFeed. Skapa ett administratörskonto för att komma igång."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Gul"

--- a/commafeed-client/src/locales/sv/messages.po
+++ b/commafeed-client/src/locales/sv/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Webbplats"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Välkommen! Det verkar vara första gången du kör CommaFeed. Skapa ett administratörskonto för att komma igång."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/tr/messages.po
+++ b/commafeed-client/src/locales/tr/messages.po
@@ -1150,6 +1150,11 @@ msgstr "Web sitesi"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Hoş geldiniz! Görünüşe göre CommaFeed'i ilk kez çalıştırıyorsunuz. Başlamak için lütfen bir yönetici hesabı oluşturun."
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "Sarı"

--- a/commafeed-client/src/locales/tr/messages.po
+++ b/commafeed-client/src/locales/tr/messages.po
@@ -1150,8 +1150,7 @@ msgstr "Web sitesi"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "Hoş geldiniz! Görünüşe göre CommaFeed'i ilk kez çalıştırıyorsunuz. Başlamak için lütfen bir yönetici hesabı oluşturun."
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr ""
 

--- a/commafeed-client/src/locales/zh/messages.po
+++ b/commafeed-client/src/locales/zh/messages.po
@@ -1150,8 +1150,7 @@ msgstr "网站"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "欢迎！当前页仅当您第一次使用CommaFeed时出现，请创建一个管理员帐号以开始使用。"
 
-#: src/pages/auth/LoginPage.tsx
-#: src/pages/auth/RegistrationPage.tsx
+#: src/app/client.ts
 msgid "Wrong username or password"
 msgstr "用户名或密码错误"
 

--- a/commafeed-client/src/locales/zh/messages.po
+++ b/commafeed-client/src/locales/zh/messages.po
@@ -1150,6 +1150,11 @@ msgstr "网站"
 msgid "Welcome! This appears to be the first time you're running CommaFeed. Please create an administrator account to get started."
 msgstr "欢迎！当前页仅当您第一次使用CommaFeed时出现，请创建一个管理员帐号以开始使用。"
 
+#: src/pages/auth/LoginPage.tsx
+#: src/pages/auth/RegistrationPage.tsx
+msgid "Wrong username or password"
+msgstr "用户名或密码错误"
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Yellow"
 msgstr "黄"

--- a/commafeed-client/src/pages/auth/LoginPage.tsx
+++ b/commafeed-client/src/pages/auth/LoginPage.tsx
@@ -5,7 +5,7 @@ import { Anchor, Box, Button, Center, Container, Group, Paper, PasswordInput, St
 import { useForm } from "@mantine/form"
 import { useAsyncCallback } from "react-async-hook"
 import { Link } from "react-router-dom"
-import { client, loginErrorToStrings } from "@/app/client"
+import { client, errorToStrings } from "@/app/client"
 import { redirectToRootCategory } from "@/app/redirect/thunks"
 import { useAppDispatch, useAppSelector } from "@/app/store"
 import type { LoginRequest } from "@/app/types"
@@ -39,7 +39,7 @@ export function LoginPage() {
                 </Title>
                 {login.error && (
                     <Box mb="md">
-                        <Alert messages={loginErrorToStrings(login.error, _(msg`Wrong username or password`))} />
+                        <Alert messages={errorToStrings(login.error)} />
                     </Box>
                 )}
                 <form onSubmit={form.onSubmit(login.execute)}>

--- a/commafeed-client/src/pages/auth/LoginPage.tsx
+++ b/commafeed-client/src/pages/auth/LoginPage.tsx
@@ -5,7 +5,7 @@ import { Anchor, Box, Button, Center, Container, Group, Paper, PasswordInput, St
 import { useForm } from "@mantine/form"
 import { useAsyncCallback } from "react-async-hook"
 import { Link } from "react-router-dom"
-import { client, errorToStrings } from "@/app/client"
+import { client, loginErrorToStrings } from "@/app/client"
 import { redirectToRootCategory } from "@/app/redirect/thunks"
 import { useAppDispatch, useAppSelector } from "@/app/store"
 import type { LoginRequest } from "@/app/types"
@@ -39,7 +39,7 @@ export function LoginPage() {
                 </Title>
                 {login.error && (
                     <Box mb="md">
-                        <Alert messages={errorToStrings(login.error)} />
+                        <Alert messages={loginErrorToStrings(login.error, _(msg`Wrong username or password`))} />
                     </Box>
                 )}
                 <form onSubmit={form.onSubmit(login.execute)}>

--- a/commafeed-client/src/pages/auth/RegistrationPage.tsx
+++ b/commafeed-client/src/pages/auth/RegistrationPage.tsx
@@ -5,7 +5,7 @@ import { Anchor, Box, Button, Center, Container, Group, Paper, PasswordInput, St
 import { useForm } from "@mantine/form"
 import { useAsyncCallback } from "react-async-hook"
 import { Link } from "react-router-dom"
-import { client, errorToStrings } from "@/app/client"
+import { client, errorToStrings, loginErrorToStrings } from "@/app/client"
 import { redirectToRootCategory } from "@/app/redirect/thunks"
 import { useAppDispatch, useAppSelector } from "@/app/store"
 import type { RegistrationRequest } from "@/app/types"
@@ -65,7 +65,7 @@ export function RegistrationPage() {
 
                         {login.error && (
                             <Box mb="md">
-                                <Alert messages={errorToStrings(login.error)} />
+                                <Alert messages={loginErrorToStrings(login.error, _(msg`Wrong username or password`))} />
                             </Box>
                         )}
 

--- a/commafeed-client/src/pages/auth/RegistrationPage.tsx
+++ b/commafeed-client/src/pages/auth/RegistrationPage.tsx
@@ -5,7 +5,7 @@ import { Anchor, Box, Button, Center, Container, Group, Paper, PasswordInput, St
 import { useForm } from "@mantine/form"
 import { useAsyncCallback } from "react-async-hook"
 import { Link } from "react-router-dom"
-import { client, errorToStrings, loginErrorToStrings } from "@/app/client"
+import { client, errorToStrings } from "@/app/client"
 import { redirectToRootCategory } from "@/app/redirect/thunks"
 import { useAppDispatch, useAppSelector } from "@/app/store"
 import type { RegistrationRequest } from "@/app/types"
@@ -65,7 +65,7 @@ export function RegistrationPage() {
 
                         {login.error && (
                             <Box mb="md">
-                                <Alert messages={loginErrorToStrings(login.error, _(msg`Wrong username or password`))} />
+                                <Alert messages={errorToStrings(login.error)} />
                             </Box>
                         )}
 

--- a/commafeed-server/src/main/java/com/commafeed/CommaFeedApplicationException.java
+++ b/commafeed-server/src/main/java/com/commafeed/CommaFeedApplicationException.java
@@ -1,0 +1,20 @@
+package com.commafeed;
+
+import java.io.Serial;
+import java.util.Objects;
+
+public class CommaFeedApplicationException extends RuntimeException {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    private final CommaFeedExceptionType type;
+
+    public CommaFeedApplicationException(CommaFeedExceptionType type) {
+        super(Objects.requireNonNull(type).message());
+        this.type = type;
+    }
+
+    public CommaFeedExceptionType type() {
+        return type;
+    }
+}

--- a/commafeed-server/src/main/java/com/commafeed/CommaFeedExceptionType.java
+++ b/commafeed-server/src/main/java/com/commafeed/CommaFeedExceptionType.java
@@ -1,0 +1,23 @@
+package com.commafeed;
+
+import org.jboss.resteasy.reactive.RestResponse.Status;
+
+public enum CommaFeedExceptionType {
+    WRONG_USERNAME_OR_PASSWORD(Status.UNAUTHORIZED, "wrong username or password");
+
+    private final Status status;
+    private final String message;
+
+    CommaFeedExceptionType(Status status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public Status status() {
+        return status;
+    }
+
+    public String message() {
+        return message;
+    }
+}

--- a/commafeed-server/src/main/java/com/commafeed/ExceptionMappers.java
+++ b/commafeed-server/src/main/java/com/commafeed/ExceptionMappers.java
@@ -26,6 +26,18 @@ public class ExceptionMappers {
     private final CookieService cookieService;
     private final CommaFeedConfiguration config;
 
+    @ServerExceptionMapper(CommaFeedApplicationException.class)
+    public RestResponse<CommaFeedApplicationError> applicationError(
+            CommaFeedApplicationException e) {
+        ResponseBuilder<CommaFeedApplicationError> response =
+                ResponseBuilder.create(
+                        e.type().status(), new CommaFeedApplicationError(e.type(), e.getMessage()));
+        if (e.type().status() == Status.UNAUTHORIZED) {
+            response.cookie(cookieService.buildLogoutCookie());
+        }
+        return response.build();
+    }
+
     @ServerExceptionMapper(UnauthorizedException.class)
     public RestResponse<UnauthorizedResponse> unauthorized(UnauthorizedException e) {
         return RestResponse.status(
@@ -55,4 +67,7 @@ public class ExceptionMappers {
 
     @RegisterForReflection
     public record ValidationFailed(String message) {}
+
+    @RegisterForReflection
+    public record CommaFeedApplicationError(CommaFeedExceptionType type, String message) {}
 }

--- a/commafeed-server/src/main/java/com/commafeed/security/identity/DatabaseUsernamePasswordIdentityProvider.java
+++ b/commafeed-server/src/main/java/com/commafeed/security/identity/DatabaseUsernamePasswordIdentityProvider.java
@@ -1,11 +1,12 @@
 package com.commafeed.security.identity;
 
+import com.commafeed.CommaFeedApplicationException;
+import com.commafeed.CommaFeedExceptionType;
 import com.commafeed.backend.dao.UnitOfWork;
 import com.commafeed.backend.model.User;
 import com.commafeed.backend.model.UserRole.Role;
 import com.commafeed.backend.service.UserService;
 
-import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.IdentityProvider;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -48,7 +49,8 @@ public class DatabaseUsernamePasswordIdentityProvider
                                                     new String(
                                                             request.getPassword().getPassword())));
                     if (user.isEmpty()) {
-                        throw new AuthenticationFailedException("wrong username or password");
+                        throw new CommaFeedApplicationException(
+                                CommaFeedExceptionType.WRONG_USERNAME_OR_PASSWORD);
                     }
 
                     Set<Role> roles = unitOfWork.call(() -> userService.getRoles(user.get()));

--- a/commafeed-server/src/test/java/com/commafeed/e2e/AuthentificationIT.java
+++ b/commafeed-server/src/test/java/com/commafeed/e2e/AuthentificationIT.java
@@ -36,7 +36,7 @@ class AuthentificationIT {
         page.navigate(getLoginPageUrl());
         PlaywrightTestUtils.login(page, TestConstants.ADMIN_USERNAME, "wrong_password");
         PlaywrightAssertions.assertThat(page.getByRole(AriaRole.ALERT))
-                .containsText("wrong username or password");
+                .containsText("Wrong username or password");
     }
 
     @Test

--- a/commafeed-server/src/test/java/com/commafeed/integration/SecurityIT.java
+++ b/commafeed-server/src/test/java/com/commafeed/integration/SecurityIT.java
@@ -1,5 +1,7 @@
 package com.commafeed.integration;
 
+import com.commafeed.CommaFeedExceptionType;
+import com.commafeed.ExceptionMappers.CommaFeedApplicationError;
 import com.commafeed.ExceptionMappers.UnauthorizedResponse;
 import com.commafeed.TestConstants;
 import com.commafeed.frontend.model.Entries;
@@ -55,6 +57,27 @@ class SecurityIT extends BaseIT {
                 .get("rest/user/profile")
                 .then()
                 .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    void formLoginWrongPassword() {
+        CommaFeedApplicationError error =
+                RestAssured.given()
+                        .auth()
+                        .none()
+                        .formParams(
+                                "j_username",
+                                TestConstants.ADMIN_USERNAME,
+                                "j_password",
+                                "wrong-password")
+                        .post("j_security_check")
+                        .then()
+                        .statusCode(HttpStatus.SC_UNAUTHORIZED)
+                        .extract()
+                        .as(CommaFeedApplicationError.class);
+
+        Assertions.assertEquals(CommaFeedExceptionType.WRONG_USERNAME_OR_PASSWORD, error.type());
+        Assertions.assertEquals("wrong username or password", error.message());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace the raw backend authentication message with a frontend-owned Lingui message for login `401` responses
- preserve backend error details for unexpected login failures
- add the new message to every locale catalog and provide the Simplified Chinese translation
- cover translated authentication errors and unexpected-error fallback behavior with unit tests

## Root cause

The backend returned `wrong username or password` as a plain English string. The client extracted the response's `message` field and rendered it directly, so the value never passed through Lingui and could not be resolved from a locale catalog.

## User impact

Invalid-login feedback now follows the selected frontend locale. Simplified Chinese users see `用户名或密码错误` instead of the backend's English text.

## Validation

- `npm run lint`
- `npm run i18n:extract`
- `npm run build`
- client test suite: 19 tests passed
- `AuthentificationIT`: 3 Playwright scenarios passed
- full Maven reactor package succeeded locally with `-Dmaven.compiler.release=24` because the available JDK is 24 while the project targets Java 25

Closes #2016
