### PR TITLE
fix: prevent desktop toolbar from wrapping into article content

### DIFF
--- a/commafeed-client/src/pages/app/Layout.test.tsx
+++ b/commafeed-client/src/pages/app/Layout.test.tsx
@@ -34,13 +34,13 @@ vi.mock(import("@/app/store"), () => ({
     useAppDispatch: () => vi.fn(),
     useAppSelector: <Selected,>(selector: (state: RootState) => Selected) => selector(appState as unknown as RootState),
 }))
-vi.mock(import("@/components/ActionButton"), () => ({
+vi.mock("@/components/ActionButton", () => ({
     ActionButton: ({ label }: { label: unknown }) => <button type="button">{String(label)}</button>,
 }))
 vi.mock(import("@/components/AnnouncementDialog"), () => ({ AnnouncementDialog: () => null }))
 vi.mock(import("@/components/DisablePullToRefresh"), () => ({ DisablePullToRefresh: () => null }))
 vi.mock(import("@/components/Logo"), () => ({ Logo: () => <span>Logo</span> }))
-vi.mock(import("@/components/MarkAllAsReadConfirmationDialog"), () => ({
+vi.mock("@/components/MarkAllAsReadConfirmationDialog", () => ({
     MarkAllAsReadConfirmationDialog: () => null,
 }))
 vi.mock(import("@/hooks/useAppLoading"), () => ({
@@ -60,12 +60,12 @@ vi.mock(import("@/hooks/useBrowserExtension"), () => ({
 }))
 vi.mock(import("@/hooks/useMobile"), () => ({ useMobile }))
 vi.mock(import("@/hooks/useWebSocket"), () => ({ useWebSocket: vi.fn() }))
-vi.mock(import("react-draggable"), () => ({
+vi.mock("react-draggable", () => ({
     default: ({ children }: { children: ReactNode }) => children,
 }))
-vi.mock(import("react-router-dom"), () => ({ Outlet: () => null }))
-vi.mock(import("react-swipeable"), () => ({ useSwipeable: () => ({}) }))
-vi.mock(import("tinycon"), () => ({
+vi.mock("react-router-dom", () => ({ Outlet: () => null }))
+vi.mock("react-swipeable", () => ({ useSwipeable: () => ({}) }))
+vi.mock("tinycon", () => ({
     default: { reset: vi.fn(), setBubble: vi.fn(), setOptions: vi.fn() },
 }))
 

--- a/commafeed-client/src/pages/app/Layout.test.tsx
+++ b/commafeed-client/src/pages/app/Layout.test.tsx
@@ -1,0 +1,132 @@
+import { MantineProvider } from "@mantine/core"
+import { act, render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { RootState } from "@/app/store"
+import Layout from "./Layout"
+
+const { appState, useMobile } = vi.hoisted(() => ({
+    appState: {
+        server: {
+            webSocketConnected: true,
+            serverInfos: undefined,
+        },
+        tree: {
+            mobileMenuOpen: false,
+            rootCategory: undefined,
+        },
+        user: {
+            localSettings: {
+                sidebarWidth: 360,
+            },
+            settings: {
+                disablePullToRefresh: false,
+                mobileFooter: false,
+                unreadCountFavicon: false,
+                unreadCountTitle: false,
+            },
+        },
+    },
+    useMobile: vi.fn(),
+}))
+
+vi.mock(import("@/app/store"), () => ({
+    useAppDispatch: () => vi.fn(),
+    useAppSelector: <Selected,>(selector: (state: RootState) => Selected) =>
+        selector(appState as unknown as RootState),
+}))
+vi.mock(import("@/components/ActionButton"), () => ({
+    ActionButton: ({ label }: { label: unknown }) => <button type="button">{String(label)}</button>,
+}))
+vi.mock(import("@/components/AnnouncementDialog"), () => ({ AnnouncementDialog: () => null }))
+vi.mock(import("@/components/DisablePullToRefresh"), () => ({ DisablePullToRefresh: () => null }))
+vi.mock(import("@/components/Logo"), () => ({ Logo: () => <span>Logo</span> }))
+vi.mock(import("@/components/MarkAllAsReadConfirmationDialog"), () => ({
+    MarkAllAsReadConfirmationDialog: () => null,
+}))
+vi.mock(import("@/hooks/useAppLoading"), () => ({
+    useAppLoading: () => ({ loading: false, loadingPercentage: 100, loadingStepLabel: undefined, steps: [] }),
+}))
+vi.mock(import("@/hooks/useBrowserExtension"), () => ({
+    useBrowserExtension: () => ({
+        browserExtensionVersion: null,
+        isBrowserExtensionInstallable: true,
+        isBrowserExtensionInstalled: false,
+        isBrowserExtensionPopup: false,
+        openAppInNewTab: vi.fn(),
+        openLinkInBackgroundTab: vi.fn(),
+        openSettingsPage: vi.fn(),
+        setBadgeUnreadCount: vi.fn(),
+    }),
+}))
+vi.mock(import("@/hooks/useMobile"), () => ({ useMobile }))
+vi.mock(import("@/hooks/useWebSocket"), () => ({ useWebSocket: vi.fn() }))
+vi.mock(import("react-draggable"), () => ({
+    default: ({ children }: { children: ReactNode }) => children,
+}))
+vi.mock(import("react-router-dom"), () => ({ Outlet: () => null }))
+vi.mock(import("react-swipeable"), () => ({ useSwipeable: () => ({}) }))
+vi.mock(import("tinycon"), () => ({
+    default: { reset: vi.fn(), setBubble: vi.fn(), setOptions: vi.fn() },
+}))
+
+const renderLayout = () =>
+    render(<Layout sidebar={<div>Sidebar</div>} sidebarVisible header={<div>Toolbar</div>} />, {
+        wrapper: MantineProvider,
+    })
+
+const groupFor = (text: string) => {
+    const group = screen.getByText(text).closest(".mantine-Group-root")
+    expect(group).not.toBeNull()
+    return group as HTMLElement
+}
+
+describe("Layout", () => {
+    beforeEach(() => {
+        appState.tree.mobileMenuOpen = false
+        appState.user.localSettings.sidebarWidth = 360
+        appState.user.settings.mobileFooter = false
+        useMobile.mockReturnValue(false)
+        Object.defineProperty(window, "innerWidth", { configurable: true, value: 1280, writable: true })
+    })
+
+    it("keeps the desktop header row and sidebar segment from wrapping", () => {
+        renderLayout()
+
+        const sidebarGroup = groupFor("CommaFeed")
+        const headerGroup = sidebarGroup.parentElement
+
+        expect(sidebarGroup).toHaveStyle({ flexShrink: "0", width: "344px" })
+        expect(sidebarGroup.style.getPropertyValue("--group-wrap")).toBe("nowrap")
+        expect(headerGroup?.style.getPropertyValue("--group-wrap")).toBe("nowrap")
+        const toolbarGroup = groupFor("Toolbar")
+        expect(toolbarGroup).toBe(headerGroup)
+        expect(screen.getByText("Toolbar").parentElement).toHaveStyle({ flexGrow: "1", minWidth: "0" })
+    })
+
+    it("keeps the toolbar in the desktop header row when the viewport loses scrollbar width", () => {
+        renderLayout()
+        const headerGroup = groupFor("Toolbar")
+
+        act(() => {
+            Object.defineProperty(window, "innerWidth", { configurable: true, value: 1263, writable: true })
+            window.dispatchEvent(new Event("resize"))
+        })
+
+        expect(groupFor("Toolbar")).toBe(headerGroup)
+        expect(headerGroup.style.getPropertyValue("--group-wrap")).toBe("nowrap")
+    })
+
+    it("does not apply the desktop constraints to the mobile menu in the footer", () => {
+        appState.tree.mobileMenuOpen = true
+        appState.user.settings.mobileFooter = true
+        useMobile.mockReturnValue(true)
+
+        renderLayout()
+
+        const mobileGroup = groupFor("CommaFeed")
+        expect(mobileGroup.closest("footer")).not.toBeNull()
+        expect(mobileGroup.style.getPropertyValue("--group-wrap")).not.toBe("nowrap")
+        expect(mobileGroup).not.toHaveStyle({ width: "344px" })
+    })
+})

--- a/commafeed-client/src/pages/app/Layout.test.tsx
+++ b/commafeed-client/src/pages/app/Layout.test.tsx
@@ -71,11 +71,11 @@ vi.mock(import("tinycon"), () => ({
 
 vi.stubGlobal(
     "ResizeObserver",
-    vi.fn(() => ({
-        disconnect: vi.fn(),
-        observe: vi.fn(),
-        unobserve: vi.fn(),
-    }))
+    class {
+        disconnect() {}
+        observe() {}
+        unobserve() {}
+    }
 )
 
 const renderLayout = () =>

--- a/commafeed-client/src/pages/app/Layout.test.tsx
+++ b/commafeed-client/src/pages/app/Layout.test.tsx
@@ -32,8 +32,7 @@ const { appState, useMobile } = vi.hoisted(() => ({
 
 vi.mock(import("@/app/store"), () => ({
     useAppDispatch: () => vi.fn(),
-    useAppSelector: <Selected,>(selector: (state: RootState) => Selected) =>
-        selector(appState as unknown as RootState),
+    useAppSelector: <Selected,>(selector: (state: RootState) => Selected) => selector(appState as unknown as RootState),
 }))
 vi.mock(import("@/components/ActionButton"), () => ({
     ActionButton: ({ label }: { label: unknown }) => <button type="button">{String(label)}</button>,
@@ -69,6 +68,15 @@ vi.mock(import("react-swipeable"), () => ({ useSwipeable: () => ({}) }))
 vi.mock(import("tinycon"), () => ({
     default: { reset: vi.fn(), setBubble: vi.fn(), setOptions: vi.fn() },
 }))
+
+vi.stubGlobal(
+    "ResizeObserver",
+    vi.fn(() => ({
+        disconnect: vi.fn(),
+        observe: vi.fn(),
+        unobserve: vi.fn(),
+    }))
+)
 
 const renderLayout = () =>
     render(<Layout sidebar={<div>Sidebar</div>} sidebarVisible header={<div>Toolbar</div>} />, {

--- a/commafeed-client/src/pages/app/Layout.tsx
+++ b/commafeed-client/src/pages/app/Layout.tsx
@@ -228,11 +228,7 @@ export default function Layout(props: Readonly<LayoutProps>) {
             </OnMobile>
             <OnDesktop>
                 <Group p="md" wrap="nowrap">
-                    <Group
-                        justify="space-between"
-                        style={{ flexShrink: 0, width: sidebarWidth - 16 }}
-                        wrap="nowrap"
-                    >
+                    <Group justify="space-between" style={{ flexShrink: 0, width: sidebarWidth - 16 }} wrap="nowrap">
                         <Box>
                             <LogoAndTitle />
                         </Box>

--- a/commafeed-client/src/pages/app/Layout.tsx
+++ b/commafeed-client/src/pages/app/Layout.tsx
@@ -227,14 +227,18 @@ export default function Layout(props: Readonly<LayoutProps>) {
                 )}
             </OnMobile>
             <OnDesktop>
-                <Group p="md">
-                    <Group justify="space-between" style={{ width: sidebarWidth - 16 }}>
+                <Group p="md" wrap="nowrap">
+                    <Group
+                        justify="space-between"
+                        style={{ flexShrink: 0, width: sidebarWidth - 16 }}
+                        wrap="nowrap"
+                    >
                         <Box>
                             <LogoAndTitle />
                         </Box>
                         <Box>{addButton}</Box>
                     </Group>
-                    <Box style={{ flexGrow: 1 }}>{props.header}</Box>
+                    <Box style={{ flexGrow: 1, minWidth: 0 }}>{props.header}</Box>
                 </Group>
             </OnDesktop>
         </>


### PR DESCRIPTION
Update the desktop header layout in `Layout.tsx` so its logo/sidebar segment and action toolbar remain on one row when the content viewport gains a vertical scrollbar, while keeping the logo segment aligned to the configured sidebar width and allowing the toolbar side to consume the remaining space. Apply the constraint to the existing production groups rather than extracting a layout helper or adding a test-only seam, and leave the mobile header/footer variants unchanged. Add a focused `Layout.test.tsx` component regression test using the repository's Vitest, Testing Library, and MantineProvider conventions, with surrounding hooks and async application services mocked only enough to render the desktop layout. On desktop Firefox on Windows, opening a sufficiently long entry can make the top toolbar wrap below its fixed-height shell header, overlaying the entry title and content and leaving the controls unusable by mouse. The thread narrows the failure to compact mode with long articles and identifies the inline-width desktop header segment at `header > div > div > div`; the symptom's dependence on long content is consistent with the Windows scrollbar reducing the available flex-row width. The current desktop header uses Mantine `Group` containers without an explicit no-wrap contract, while reserving a fixed-width segment for the logo and subscribe button. There are no assignees, claims, competing PRs, or closed-unmerged prior attempts in the supplied issue evidence.

Testing: Render the desktop layout with the default 360px sidebar and verify the logo/subscribe segment retains its expected sidebar-relative width while the containing header row is explicitly non-wrapping; Simulate the desktop viewport width changing by a scrollbar-sized amount and verify the toolbar remains in the same header row rather than flowing below the fixed 60px header.

Fixes #2080
