### PR TITLE
Add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ PikaPods shares 20% of the revenue back to CommaFeed.
 
 [![PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=commafeed)
 
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/CommaFeed/)
+
 ### Download a precompiled package
 
 Go to the [release page](https://github.com/Athou/commafeed/releases) and download the latest version for your operating

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ PikaPods shares 20% of the revenue back to CommaFeed.
 
 [![PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=commafeed)
 
-[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/CommaFeed/)
+<a href="https://repocloud.io/details/CommaFeed/"><img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="32"></a>
 
 ### Download a precompiled package
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ PikaPods shares 20% of the revenue back to CommaFeed.
 
 [![PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=commafeed)
 
-<a href="https://repocloud.io/details/CommaFeed/"><img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="32"></a>
+<a href="https://repocloud.io/details/CommaFeed/"><img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="38"></a>
 
 ### Download a precompiled package
 


### PR DESCRIPTION
Added RepoCloud as a one-click deployment option in the Cloud hosting section alongside PikaPods.

RepoCloud offers an easy way to deploy CommaFeed with one click at reduced cost.