### PR TITLE
Add generic custom sharing destinations (#1102)

### DIFF
--- a/commafeed-client/src/app/constants.ts
+++ b/commafeed-client/src/app/constants.ts
@@ -1,6 +1,5 @@
 import type { IconType } from "react-icons"
 import { FaAt } from "react-icons/fa"
-import { SiBuffer, SiFacebook, SiGmail, SiInstapaper, SiTumblr, SiX } from "react-icons/si"
 import type { Category, Entry, SharingSettings } from "./types"
 
 const categories: Record<string, Omit<Category, "name">> = {
@@ -23,7 +22,13 @@ const categories: Record<string, Omit<Category, "name">> = {
 const sharing: {
     [key in keyof SharingSettings]: {
         label: string
-        icon: IconType
+        // a direct IconType component (rendered as-is), or a react-icons/si export name string
+        // (resolved dynamically via siIcons.ts). Never statically import from "react-icons/si"
+        // here - custom sharing's icon picker already does a dynamic `import("react-icons/si")`
+        // with runtime property access, and any static import of that same module anywhere in
+        // the app defeats code-splitting for it (the whole ~3300-icon module then lands in the
+        // main bundle instead of its own lazily-loaded chunk).
+        icon: IconType | string
         color: `#${string}`
         url: (url: string, description: string) => string
     }
@@ -36,37 +41,37 @@ const sharing: {
     },
     gmail: {
         label: "Gmail",
-        icon: SiGmail,
+        icon: "SiGmail",
         color: "#EA4335",
         url: (url, desc) => `https://mail.google.com/mail/?view=cm&fs=1&tf=1&source=mailto&su=${desc}&body=${url}`,
     },
     facebook: {
         label: "Facebook",
-        icon: SiFacebook,
+        icon: "SiFacebook",
         color: "#1B74E4",
         url: url => `https://www.facebook.com/sharer/sharer.php?u=${url}`,
     },
     twitter: {
         label: "X",
-        icon: SiX,
+        icon: "SiX",
         color: "#000000",
         url: (url, desc) => `https://x.com/share?text=${desc}&url=${url}`,
     },
     tumblr: {
         label: "Tumblr",
-        icon: SiTumblr,
+        icon: "SiTumblr",
         color: "#375672",
         url: (url, desc) => `https://www.tumblr.com/share/link?url=${url}&name=${desc}`,
     },
     instapaper: {
         label: "Instapaper",
-        icon: SiInstapaper,
+        icon: "SiInstapaper",
         color: "#010101",
         url: (url, desc) => `https://www.instapaper.com/hello2?url=${url}&title=${desc}`,
     },
     buffer: {
         label: "Buffer",
-        icon: SiBuffer,
+        icon: "SiBuffer",
         color: "#000000",
         url: (url, desc) => `https://bufferapp.com/add?url=${url}&text=${desc}`,
     },

--- a/commafeed-client/src/app/customSharing.test.ts
+++ b/commafeed-client/src/app/customSharing.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { buildCustomSharingUrl } from "@/app/customSharing"
+
+describe("buildCustomSharingUrl", () => {
+    it("replaces url and title placeholders", () => {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: ${url}/${title} are the literal placeholder syntax, not a forgotten template string
+        const result = buildCustomSharingUrl("https://example.com/save?url=${url}&title=${title}", "https://a.com/x", "My Title")
+        expect(result).toBe("https://example.com/save?url=https%3A%2F%2Fa.com%2Fx&title=My%20Title")
+    })
+
+    it("handles a pattern using only one of the two placeholders", () => {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: ${url} is the literal placeholder syntax, not a forgotten template string
+        const result = buildCustomSharingUrl("https://example.com/save?url=${url}", "https://a.com/x", "My Title")
+        expect(result).toBe("https://example.com/save?url=https%3A%2F%2Fa.com%2Fx")
+    })
+
+    it("handles multiple occurrences of the same placeholder", () => {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: ${url} is the literal placeholder syntax, not a forgotten template string
+        const result = buildCustomSharingUrl("https://example.com/${url}/again/${url}", "https://a.com/x", "My Title")
+        expect(result).toBe("https://example.com/https%3A%2F%2Fa.com%2Fx/again/https%3A%2F%2Fa.com%2Fx")
+    })
+
+    it("passes through patterns with no placeholders unchanged", () => {
+        const result = buildCustomSharingUrl("https://example.com/save", "https://a.com/x", "My Title")
+        expect(result).toBe("https://example.com/save")
+    })
+
+    it("encodes special characters without double-encoding", () => {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: ${url} is the literal placeholder syntax, not a forgotten template string
+        const result = buildCustomSharingUrl("https://example.com/save?url=${url}", "https://a.com/x?a=1&b=2 space", "Title & More")
+        expect(result).toBe("https://example.com/save?url=https%3A%2F%2Fa.com%2Fx%3Fa%3D1%26b%3D2%20space")
+    })
+})

--- a/commafeed-client/src/app/customSharing.ts
+++ b/commafeed-client/src/app/customSharing.ts
@@ -1,0 +1,7 @@
+// Substitutes ${url} and ${title} placeholders in a user-defined URL pattern with the
+// entry's raw url/title, encoding each variable at substitution time. Callers must pass
+// RAW (unencoded) values here - built-in share sites' pre-encoded url/desc consts are
+// only correct for their own url() builder functions and would double-encode if reused.
+export function buildCustomSharingUrl(pattern: string, url: string, title: string): string {
+    return pattern.replace(/\$\{url\}/g, encodeURIComponent(url)).replace(/\$\{title\}/g, encodeURIComponent(title))
+}

--- a/commafeed-client/src/app/siIcons.ts
+++ b/commafeed-client/src/app/siIcons.ts
@@ -1,0 +1,20 @@
+import type { IconType } from "react-icons"
+
+// react-icons/si (Simple Icons) has ~3300 exports, so it must never be part of the main
+// bundle. This module-level cached promise ensures the dynamic import is only triggered
+// once and shared by every consumer (the icon picker and however many custom sharing
+// buttons render at once), rather than each one independently re-invoking import().
+let cache: Promise<Record<string, IconType>> | undefined
+
+export function loadSiIcons(): Promise<Record<string, IconType>> {
+    if (!cache) {
+        cache = (import("react-icons/si") as unknown as Promise<Record<string, IconType>>).catch(e => {
+            // don't keep a rejected promise cached: a transient chunk load failure (flaky
+            // network, or stale asset hashes right after a deploy) would otherwise disable
+            // icons for the rest of the session, with a reload as the only way out
+            cache = undefined
+            throw e
+        })
+    }
+    return cache
+}

--- a/commafeed-client/src/app/types.ts
+++ b/commafeed-client/src/app/types.ts
@@ -263,6 +263,12 @@ export interface PushNotificationSettings {
     topic?: string
 }
 
+export interface CustomSharingDestination {
+    name: string
+    urlPattern: string
+    icon: string
+}
+
 export interface Settings {
     language?: string
     readingMode: ReadingMode
@@ -286,6 +292,7 @@ export interface Settings {
     primaryColor?: string
     sharingSettings: SharingSettings
     pushNotificationSettings: PushNotificationSettings
+    customSharingDestinations: CustomSharingDestination[]
 }
 
 export interface LocalSettings {

--- a/commafeed-client/src/components/content/ShareButtons.tsx
+++ b/commafeed-client/src/components/content/ShareButtons.tsx
@@ -1,8 +1,11 @@
 import { Trans } from "@lingui/react/macro"
 import { ActionIcon, Box, CopyButton, Divider, SimpleGrid } from "@mantine/core"
+import { useAsync } from "react-async-hook"
 import type { IconType } from "react-icons"
-import { TbCheck, TbCopy, TbDeviceDesktopShare, TbDeviceMobileShare } from "react-icons/tb"
+import { TbCheck, TbCopy, TbDeviceDesktopShare, TbDeviceMobileShare, TbLink } from "react-icons/tb"
 import { Constants } from "@/app/constants"
+import { buildCustomSharingUrl } from "@/app/customSharing"
+import { loadSiIcons } from "@/app/siIcons"
 import { useAppSelector } from "@/app/store"
 import type { SharingSettings } from "@/app/types"
 import { useBrowserExtension } from "@/hooks/useBrowserExtension"
@@ -54,7 +57,8 @@ function SiteShareButton({
     url: string
 }>) {
     const onClick = () => {
-        window.open(url, "", "menubar=no,toolbar=no,resizable=yes,scrollbars=yes,width=800,height=600")
+        const win = window.open(url, "", "menubar=no,toolbar=no,resizable=yes,scrollbars=yes,width=800,height=600")
+        if (win) win.opener = null
     }
 
     return <ShareButton icon={icon} color={color} onClick={onClick} />
@@ -104,15 +108,24 @@ export function ShareButtons(
     }>
 ) {
     const sharingSettings = useAppSelector(state => state.user.settings?.sharingSettings)
+    const customSharingDestinations = useAppSelector(state => state.user.settings?.customSharingDestinations ?? [])
     const enabledSharingSites = (Object.keys(Constants.sharing) as Array<keyof SharingSettings>).filter(site => sharingSettings?.[site])
     const url = encodeURIComponent(props.url)
     const desc = encodeURIComponent(props.description)
     const clipboardAvailable = typeof navigator.clipboard !== "undefined"
     const nativeSharingAvailable = typeof navigator.share !== "undefined"
     const showNativeSection = clipboardAvailable || nativeSharingAvailable
-    const showSharingSites = enabledSharingSites.length > 0
+    const showSharingSites = enabledSharingSites.length > 0 || customSharingDestinations.length > 0
     const showDivider = showNativeSection && showSharingSites
     const showNoSharingOptionsAvailable = !showNativeSection && !showSharingSites
+
+    // react-icons/si (~3300 exports) is only fetched once there's actually something to
+    // render an icon for - most built-in sites resolve their icon name through this too
+    // (see the comment on Constants.sharing), so it's gated on showSharingSites rather than
+    // customSharingDestinations alone.
+    const { result: siIcons } = useAsync(showSharingSites ? loadSiIcons : async () => undefined, [showSharingSites])
+
+    const resolveIcon = (icon: IconType | string): IconType => (typeof icon === "string" ? (siIcons?.[icon] ?? TbLink) : icon)
 
     return (
         <>
@@ -130,9 +143,18 @@ export function ShareButtons(
                     {enabledSharingSites.map(site => (
                         <SiteShareButton
                             key={site}
-                            icon={Constants.sharing[site].icon}
+                            icon={resolveIcon(Constants.sharing[site].icon)}
                             color={Constants.sharing[site].color}
                             url={Constants.sharing[site].url(url, desc)}
+                        />
+                    ))}
+                    {customSharingDestinations.map(destination => (
+                        // names are validated unique server-side, so they make a stable key
+                        <SiteShareButton
+                            key={destination.name}
+                            icon={resolveIcon(destination.icon)}
+                            color="#000"
+                            url={buildCustomSharingUrl(destination.urlPattern, props.url, props.description)}
                         />
                     ))}
                 </SimpleGrid>

--- a/commafeed-client/src/components/settings/CustomSharingSettings.tsx
+++ b/commafeed-client/src/components/settings/CustomSharingSettings.tsx
@@ -1,0 +1,156 @@
+import { msg } from "@lingui/core/macro"
+import { useLingui } from "@lingui/react"
+import { Trans } from "@lingui/react/macro"
+import { ActionIcon, Button, Code, Group, Stack, Text, TextInput } from "@mantine/core"
+import { useForm } from "@mantine/form"
+import { useEffect, useRef, useState } from "react"
+import { useAsyncCallback } from "react-async-hook"
+import { TbDeviceFloppy, TbPlus, TbTrash } from "react-icons/tb"
+import { client, errorToStrings } from "@/app/client"
+import { useAppDispatch, useAppSelector } from "@/app/store"
+import type { CustomSharingDestination, Settings } from "@/app/types"
+import { reloadSettings } from "@/app/user/thunks"
+import { Alert } from "@/components/Alert"
+import { IconPicker } from "@/components/settings/IconPicker"
+
+interface FormValues {
+    destinations: CustomSharingDestination[]
+}
+
+// Kept out of the <Trans> blocks below on purpose: these are literal placeholder/URL syntax,
+// not translatable prose, and lingui would otherwise parse `${url}` as an ICU message argument
+// and render it as an empty string.
+// biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder the user types into the URL pattern
+const URL_PLACEHOLDER = "${url}"
+// biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder the user types into the URL pattern
+const TITLE_PLACEHOLDER = "${title}"
+// biome-ignore lint/suspicious/noTemplateCurlyInString: literal placeholder inside the example URL
+const EXAMPLE_PATTERN = "https://readeck.example.com/bookmarks/unread?url=${url}"
+
+export function CustomSharingSettings() {
+    const settings = useAppSelector(state => state.user.settings)
+    const dispatch = useAppDispatch()
+    const { _ } = useLingui()
+
+    // CustomSharingDestination has no id field (matches the DB schema), so rows need a
+    // separate client-side-only stable key, kept in sync with the form's destinations array.
+    const [rowKeys, setRowKeys] = useState<string[]>([])
+
+    const form = useForm<FormValues>({
+        initialValues: { destinations: [] },
+        validate: {
+            destinations: {
+                name: value => (value.trim().length === 0 ? _(msg`Name is required`) : null),
+                urlPattern: value => (/^https?:\/\//i.test(value) ? null : _(msg`Must start with http:// or https://`)),
+                icon: value => (value ? null : _(msg`Icon is required`)),
+            },
+        },
+    })
+    // Sync local form state from Redux only when the settings object actually changes (initial
+    // load, or after a save's reloadSettings()) - NOT on every render. `form.setValues` is only
+    // referentially stable when the `validate` option passed to useForm is stable, which it
+    // isn't here (a fresh object literal every render), so depending on it directly in a
+    // useEffect deps array would re-run this sync (and clobber in-progress edits) on every
+    // render instead of only when `settings` changes.
+    const syncedSettingsRef = useRef<typeof settings>(undefined)
+    // Set when this component triggers the reload itself: the response only echoes back what we
+    // just saved, so re-seeding the form from it would discard anything typed while the request
+    // was in flight.
+    const skipNextSyncRef = useRef(false)
+    useEffect(() => {
+        if (settings && syncedSettingsRef.current !== settings) {
+            syncedSettingsRef.current = settings
+            if (skipNextSyncRef.current) {
+                skipNextSyncRef.current = false
+                return
+            }
+            // Copy each destination: redux-toolkit freezes state objects, and @mantine/form
+            // mutates its values in place, so handing it the frozen objects directly makes
+            // setFieldValue throw "TypeError: <prop> is read-only" on the first edit.
+            form.setValues({ destinations: settings.customSharingDestinations.map(d => ({ ...d })) })
+            // Reuse existing keys when the row count is unchanged (the usual case after a save
+            // triggers reloadSettings) - regenerating them would remount every row for nothing.
+            setRowKeys(keys =>
+                keys.length === settings.customSharingDestinations.length
+                    ? keys
+                    : settings.customSharingDestinations.map(() => crypto.randomUUID())
+            )
+        }
+    })
+
+    const addDestination = () => {
+        form.insertListItem("destinations", { name: "", urlPattern: "", icon: "" })
+        setRowKeys(keys => [...keys, crypto.randomUUID()])
+    }
+
+    const removeDestination = (index: number) => {
+        form.removeListItem("destinations", index)
+        setRowKeys(keys => keys.filter((_key, i) => i !== index))
+    }
+
+    const save = useAsyncCallback(
+        async (destinations: CustomSharingDestination[]) => {
+            if (!settings) return
+            const updated: Settings = { ...settings, customSharingDestinations: destinations }
+            await client.user.saveSettings(updated)
+        },
+        {
+            onSuccess: () => {
+                skipNextSyncRef.current = true
+                dispatch(reloadSettings())
+            },
+        }
+    )
+
+    return (
+        <form onSubmit={form.onSubmit(values => save.execute(values.destinations))}>
+            <Stack>
+                {save.error && <Alert level="error" messages={errorToStrings(save.error)} />}
+
+                <Stack gap={4}>
+                    <Text size="sm" c="dimmed">
+                        <Trans>
+                            Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these
+                            placeholders replaced by the entry's values:
+                        </Trans>{" "}
+                        <Code>{URL_PLACEHOLDER}</Code> <Code>{TITLE_PLACEHOLDER}</Code>
+                    </Text>
+                    <Text size="sm" c="dimmed">
+                        <Trans>
+                            The rest of the pattern depends on the service you are using - check its documentation for the address that adds
+                            a link. For example, Readeck:
+                        </Trans>{" "}
+                        <Code>{EXAMPLE_PATTERN}</Code>
+                    </Text>
+                </Stack>
+
+                {form.values.destinations.map((destination, index) => (
+                    <Group key={rowKeys[index] ?? index} align="flex-start" wrap="nowrap">
+                        <IconPicker value={destination.icon} onChange={icon => form.setFieldValue(`destinations.${index}.icon`, icon)} />
+                        <TextInput placeholder={_(msg`Name`)} style={{ flex: 1 }} {...form.getInputProps(`destinations.${index}.name`)} />
+                        <TextInput
+                            placeholder="https://example.com/save?url=${url}&title=${title}"
+                            style={{ flex: 2 }}
+                            {...form.getInputProps(`destinations.${index}.urlPattern`)}
+                        />
+                        <ActionIcon variant="subtle" color="red" onClick={() => removeDestination(index)}>
+                            <TbTrash size={18} />
+                        </ActionIcon>
+                    </Group>
+                ))}
+
+                <Group>
+                    <Button variant="default" leftSection={<TbPlus size={16} />} onClick={addDestination}>
+                        <Trans>Add destination</Trans>
+                    </Button>
+                </Group>
+
+                <Group>
+                    <Button type="submit" leftSection={<TbDeviceFloppy size={16} />} loading={save.loading}>
+                        <Trans>Save</Trans>
+                    </Button>
+                </Group>
+            </Stack>
+        </form>
+    )
+}

--- a/commafeed-client/src/components/settings/IconPicker.tsx
+++ b/commafeed-client/src/components/settings/IconPicker.tsx
@@ -1,0 +1,97 @@
+import { msg } from "@lingui/core/macro"
+import { useLingui } from "@lingui/react"
+import { ActionIcon, Box, Popover, SimpleGrid, TextInput } from "@mantine/core"
+import { useState } from "react"
+import { useAsync } from "react-async-hook"
+import { TbPhoto } from "react-icons/tb"
+import { loadSiIcons } from "@/app/siIcons"
+import { Loader } from "@/components/Loader"
+import { tss } from "@/tss"
+
+const MAX_RESULTS = 200
+
+const useStyles = tss.create(({ theme, colorScheme }) => ({
+    trigger: {
+        cursor: "pointer",
+        color: colorScheme === "dark" ? theme.colors.gray[2] : "black",
+    },
+}))
+
+interface IconPickerProps {
+    value: string
+    onChange: (icon: string) => void
+}
+
+export function IconPicker(props: Readonly<IconPickerProps>) {
+    const { classes } = useStyles()
+    const { _ } = useLingui()
+    const [opened, setOpened] = useState(false)
+    const [hasOpened, setHasOpened] = useState(false)
+    const [query, setQuery] = useState("")
+
+    // Only fetch the ~3300-export react-icons/si module when it's actually needed: either the
+    // picker has been opened, or there's already a selected icon whose name we must resolve to
+    // render the trigger's preview. Gating on `opened` alone would wipe the resolved icons (and
+    // the preview with them) whenever the popover closes or the row remounts after a save.
+    const needsIcons = hasOpened || props.value.length > 0
+    const { result: icons } = useAsync(needsIcons ? loadSiIcons : async () => undefined, [needsIcons])
+
+    const SelectedIcon = icons?.[props.value]
+
+    const filteredNames = icons
+        ? Object.keys(icons)
+              .filter(name => name.toLowerCase().includes(query.toLowerCase()))
+              .slice(0, MAX_RESULTS)
+        : []
+
+    return (
+        <Popover withArrow withinPortal shadow="md" opened={opened} onChange={setOpened}>
+            <Popover.Target>
+                <ActionIcon
+                    variant="default"
+                    size="lg"
+                    className={classes.trigger}
+                    onClick={() => {
+                        setOpened(o => !o)
+                        setHasOpened(true)
+                    }}
+                >
+                    {SelectedIcon ? SelectedIcon({ size: 18 }) : <TbPhoto size={18} />}
+                </ActionIcon>
+            </Popover.Target>
+            <Popover.Dropdown w={320}>
+                <TextInput
+                    placeholder={_(msg`Search icons`)}
+                    value={query}
+                    onChange={event => setQuery(event.currentTarget.value)}
+                    mb="xs"
+                />
+                {!icons && <Loader />}
+                {icons && (
+                    <Box style={{ height: 240, overflowY: "auto" }}>
+                        <SimpleGrid cols={6} spacing="xs">
+                            {filteredNames.map(name => {
+                                const Icon = icons[name]
+                                const selected = name === props.value
+                                return (
+                                    <ActionIcon
+                                        key={name}
+                                        title={name}
+                                        variant={selected ? "filled" : "subtle"}
+                                        size="lg"
+                                        onClick={() => {
+                                            props.onChange(name)
+                                            setOpened(false)
+                                        }}
+                                    >
+                                        {Icon({ size: 20, style: { pointerEvents: "none" } })}
+                                    </ActionIcon>
+                                )
+                            })}
+                        </SimpleGrid>
+                    </Box>
+                )}
+            </Popover.Dropdown>
+        </Popover>
+    )
+}

--- a/commafeed-client/src/locales/ar/messages.po
+++ b/commafeed-client/src/locales/ar/messages.po
@@ -50,6 +50,10 @@ msgstr "إضافة"
 msgid "Add category"
 msgstr "إضافة فئة"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "إضافة مستخدم"
@@ -270,6 +274,10 @@ msgstr "قواعد CSS المخصصة التي سيتم تطبيقها"
 msgid "Custom JS code that will be executed on page load"
 msgstr "كود JS المخصص الذي سيتم تنفيذه عند تحميل الصفحة"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "سيان"
@@ -286,6 +294,10 @@ msgstr "تاريخ الإنشاء"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "أيام"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "رمادي"
 msgid "Green"
 msgstr "أخضر"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "المرجع نفسه"
@@ -627,17 +643,26 @@ msgstr "تحريك الصفحة لأسفل"
 msgid "Move the page up"
 msgstr "تحريك الصفحة لأعلى"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "لا"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "الاسم"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "نقرة بالزر الأيمن"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "التمرير"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "بحث"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "اختبار"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "تم إرسال إشعار الاختبار بنجاح."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/ca/messages.po
+++ b/commafeed-client/src/locales/ca/messages.po
@@ -50,6 +50,10 @@ msgstr "Afegeix"
 msgid "Add category"
 msgstr "Afegeix categoria"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Afegeix usuari"
@@ -270,6 +274,10 @@ msgstr "Regles CSS personalitzades que s'aplicaran"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Codi JS personalitzat que s'executarà en carregar la pàgina"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Cian"
@@ -286,6 +294,10 @@ msgstr "Data de creació"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "dies"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Gris"
 msgid "Green"
 msgstr "Verd"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Mou la pàgina cap avall"
 msgid "Move the page up"
 msgstr "Mou la pàgina cap amunt"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "No es coneix"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Nom"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Clic dret"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Desplaçament"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Cerca"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Prova"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "La notificació de prova s'ha enviat correctament."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/cs/messages.po
+++ b/commafeed-client/src/locales/cs/messages.po
@@ -50,6 +50,10 @@ msgstr "Přidej"
 msgid "Add category"
 msgstr "Přidat kategorii"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Přidat uživatele"
@@ -270,6 +274,10 @@ msgstr "Vlastní pravidla CSS, která budou použita"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Vlastní kód JS, který bude spuštěn při načtení stránky"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Azurová"
@@ -286,6 +294,10 @@ msgstr "Datum vytvoření"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "dní"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Šedá"
 msgid "Green"
 msgstr "Zelená"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "ID"
@@ -627,17 +643,26 @@ msgstr "Přesuňte stránku dolů"
 msgid "Move the page up"
 msgstr "Přesuňte stránku nahoru"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/A"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Jméno"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Kliknutí pravým tlačítkem"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Posouvání"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Hledej"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Testovat"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Testovací oznámení bylo úspěšně odesláno."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/cy/messages.po
+++ b/commafeed-client/src/locales/cy/messages.po
@@ -50,6 +50,10 @@ msgstr "Ychwanegu"
 msgid "Add category"
 msgstr "Ychwanegu categori"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Ychwanegu defnyddiwr"
@@ -270,6 +274,10 @@ msgstr "Rheolau CSS arferol a fydd yn cael eu cymhwyso"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Cod JS arferol a fydd yn cael ei weithredu wrth lwytho'r dudalen"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Cyan"
@@ -286,6 +294,10 @@ msgstr "Dyddiad creu"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "diwrnodau"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Llwyd"
 msgid "Green"
 msgstr "Gwyrdd"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Symudwch y dudalen i lawr"
 msgid "Move the page up"
 msgstr "Symudwch y dudalen i fyny"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "Amh"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Enw"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Clic dde"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Sgrolio"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Chwilio"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Prawf"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Anfonwyd yr hysbysiad prawf yn llwyddiannus."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/da/messages.po
+++ b/commafeed-client/src/locales/da/messages.po
@@ -50,6 +50,10 @@ msgstr "Tilføj"
 msgid "Add category"
 msgstr "Tilføj kategori"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Tilføj bruger"
@@ -270,6 +274,10 @@ msgstr "Brugerdefinerede CSS-regler, der vil blive anvendt"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Brugerdefineret JS-kode, der vil blive eksekveret ved sideindlæsning"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Cyan"
@@ -286,6 +294,10 @@ msgstr "Dato oprettet"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "dage"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Grå"
 msgid "Green"
 msgstr "Grøn"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Flyt siden ned"
 msgid "Move the page up"
 msgstr "Flyt siden op"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/A"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Navn"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Højreklik"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Rulning"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Søg"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Testmeddelelse sendt med succes."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/de/messages.po
+++ b/commafeed-client/src/locales/de/messages.po
@@ -50,6 +50,10 @@ msgstr "Hinzufügen"
 msgid "Add category"
 msgstr "Kategorie hinzufügen"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Benutzer hinzufügen"
@@ -270,6 +274,10 @@ msgstr "Eigene CSS Regeln die angewandt werden"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Einer JS Code der beim Laden der Seite ausgeführt wird"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Cyan"
@@ -286,6 +294,10 @@ msgstr "Erstellungsdatum"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "Tage"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Grau"
 msgid "Green"
 msgstr "Grün"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "ID"
@@ -627,17 +643,26 @@ msgstr "Seite nach unten verschieben"
 msgid "Move the page up"
 msgstr "Bewege die Seite nach oben"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "n.v."
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Name"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Rechtsklick"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Scrollen"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Suche"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Testbenachrichtigung erfolgreich gesendet."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/en/messages.po
+++ b/commafeed-client/src/locales/en/messages.po
@@ -50,6 +50,10 @@ msgstr "Add"
 msgid "Add category"
 msgstr "Add category"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr "Add destination"
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Add user"
@@ -270,6 +274,10 @@ msgstr "Custom CSS rules that will be applied"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Custom JS code that will be executed on page load"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr "Custom sharing"
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Cyan"
@@ -286,6 +294,10 @@ msgstr "Date created"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "days"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Gray"
 msgid "Green"
 msgstr "Green"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr "Icon is required"
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Move the page down"
 msgid "Move the page up"
 msgstr "Move the page up"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr "Must start with http:// or https://"
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/A"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Name"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr "Name is required"
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Right click"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Scrolling"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Search"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr "Search icons"
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Test notification sent successfully."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/es/messages.po
+++ b/commafeed-client/src/locales/es/messages.po
@@ -51,6 +51,10 @@ msgstr "Añadir"
 msgid "Add category"
 msgstr "Añadir categoría"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Añadir usuario"
@@ -271,6 +275,10 @@ msgstr "Reglas CSS personalizadas que se aplicarán"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Código JS personalizado que se ejecutará al cargar la página"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Cian"
@@ -287,6 +295,10 @@ msgstr "Fecha de creación"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "días"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -479,6 +491,10 @@ msgstr "Gris"
 msgid "Green"
 msgstr "Verde"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Identificación"
@@ -628,17 +644,26 @@ msgstr "Mover la página hacia abajo"
 msgid "Move the page up"
 msgstr "Mover la página hacia arriba"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/D"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Nombre"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -882,6 +907,7 @@ msgstr "Clic derecho"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -905,6 +931,10 @@ msgstr "Desplazarse"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Buscar"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1063,6 +1093,10 @@ msgstr "Probar"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Notificación de prueba enviada con éxito."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/fa/messages.po
+++ b/commafeed-client/src/locales/fa/messages.po
@@ -50,6 +50,10 @@ msgstr "اضافه کنید"
 msgid "Add category"
 msgstr "اضافه کردن دسته"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "افزودن کاربر"
@@ -270,6 +274,10 @@ msgstr "قوانین CSS سفارشی که اعمال خواهد شد"
 msgid "Custom JS code that will be executed on page load"
 msgstr "کد JS سفارشی که در بارگذاری صفحه اجرا می شود"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "فیروزه‌ای"
@@ -286,6 +294,10 @@ msgstr "تاریخ ایجاد"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "روز"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "خاکستری"
 msgid "Green"
 msgstr "سبز"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "شناسه"
@@ -627,17 +643,26 @@ msgstr "صفحه را به پایین ببرید"
 msgid "Move the page up"
 msgstr "صفحه را به بالا ببرید"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "ناموجود"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "نام"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "راست کلیک"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "پیمایش"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "جستجو"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "تست"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "اعلان تستی با موفقیت ارسال شد."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/fi/messages.po
+++ b/commafeed-client/src/locales/fi/messages.po
@@ -50,6 +50,10 @@ msgstr "Lisää"
 msgid "Add category"
 msgstr "Lisää luokka"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Lisää käyttäjä"
@@ -270,6 +274,10 @@ msgstr "Sovellettavat mukautetut CSS-säännöt"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Mukautettu JS-koodi, joka suoritetaan sivun latautuessa"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Syaani"
@@ -286,6 +294,10 @@ msgstr "Luontipäivämäärä"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "päivää"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Harmaa"
 msgid "Green"
 msgstr "Vihreä"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Tunnus"
@@ -627,17 +643,26 @@ msgstr "Siirrä sivua alaspäin"
 msgid "Move the page up"
 msgstr "Siirrä sivua ylöspäin"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "–"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Nimi"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Oikea napsautus"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Vieritys"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Etsi"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Testi"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Testi-ilmoitus lähetetty onnistuneesti."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/fr/messages.po
+++ b/commafeed-client/src/locales/fr/messages.po
@@ -50,6 +50,10 @@ msgstr "Ajouter"
 msgid "Add category"
 msgstr "Ajouter une catégorie"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Ajouter un utilisateur"
@@ -270,6 +274,10 @@ msgstr "Code CSS personnalisé qui sera appliqué"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Code JS personnalisé qui sera appliqué au chargement des pages"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Cyan"
@@ -286,6 +294,10 @@ msgstr "Date de création"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "jours"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Gris"
 msgid "Green"
 msgstr "Vert"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Identifiant"
@@ -627,17 +643,26 @@ msgstr "Faites défiler la page vers le bas"
 msgid "Move the page up"
 msgstr "Faites défiler la page vers le haut"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/A"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Nom"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Clic droit"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Défilement"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Rechercher"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Notification de test envoyée avec succès."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/gl/messages.po
+++ b/commafeed-client/src/locales/gl/messages.po
@@ -51,6 +51,10 @@ msgstr "Engadir"
 msgid "Add category"
 msgstr "Engadir categoría"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Engadir persoa usuaria"
@@ -271,6 +275,10 @@ msgstr "Regras persoais de CSS que se van aplicar"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Código JS persoal que se executará ao cargar a páxina"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Ciano"
@@ -287,6 +295,10 @@ msgstr "Data de creación"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "días"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -479,6 +491,10 @@ msgstr "Gris"
 msgid "Green"
 msgstr "Verde"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -628,17 +644,26 @@ msgstr "Move a páxina cara abaixo"
 msgid "Move the page up"
 msgstr "Move a páxina cara arriba"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/A"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Nome"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -882,6 +907,7 @@ msgstr "Botón dereito"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -905,6 +931,10 @@ msgstr "Desprazamento"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Busca"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1063,6 +1093,10 @@ msgstr "Proba"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Notificación de proba enviada correctamente."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/hu/messages.po
+++ b/commafeed-client/src/locales/hu/messages.po
@@ -50,6 +50,10 @@ msgstr "Hozzáadás"
 msgid "Add category"
 msgstr "Kategória hozzáadása"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Felhasználó hozzáadása"
@@ -270,6 +274,10 @@ msgstr "Alkalmazandó egyedi CSS szabályok"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Az oldal betöltésekor végrehajtandó egyedi JS kód"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Ciánkék"
@@ -286,6 +294,10 @@ msgstr "Létrehozás dátuma"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "nap"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Szürke"
 msgid "Green"
 msgstr "Zöld"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Mozgassa le az oldalt"
 msgid "Move the page up"
 msgstr "Mozgassa felfelé az oldalt"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/A"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Név"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Jobb klikk"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Görgetés"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Keresés"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Teszt"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "A tesztértesítés sikeresen elküldve."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/id/messages.po
+++ b/commafeed-client/src/locales/id/messages.po
@@ -50,6 +50,10 @@ msgstr "Tambahkan"
 msgid "Add category"
 msgstr "Tambahkan kategori"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Tambahkan pengguna"
@@ -270,6 +274,10 @@ msgstr "Aturan CSS khusus yang akan diterapkan"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Kode JS khusus yang akan dieksekusi saat pemuatan halaman"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Sian"
@@ -286,6 +294,10 @@ msgstr "Tanggal dibuat"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "hari"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Abu-abu"
 msgid "Green"
 msgstr "Hijau"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Pindahkan halaman ke bawah"
 msgid "Move the page up"
 msgstr "Pindahkan halaman ke atas"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "T/A"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Nama"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Klik kanan"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Menggulir"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Pencarian"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Tes"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Notifikasi tes berhasil dikirim."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/it/messages.po
+++ b/commafeed-client/src/locales/it/messages.po
@@ -50,6 +50,10 @@ msgstr "Aggiungi"
 msgid "Add category"
 msgstr "Aggiungi categoria"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Aggiungi utente"
@@ -270,6 +274,10 @@ msgstr "Regole CSS personalizzate che verranno applicate"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Codice JS personalizzato che verrà eseguito al caricamento della pagina"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Ciano"
@@ -286,6 +294,10 @@ msgstr "Data di creazione"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "giorni"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Grigio"
 msgid "Green"
 msgstr "Verde"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "ID"
@@ -627,17 +643,26 @@ msgstr "Sposta la pagina in basso"
 msgid "Move the page up"
 msgstr "Sposta la pagina in alto"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/D"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Nome"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Clic destro"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Scorrimento"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Cerca"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Notifica di prova inviata con successo."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/ja/messages.po
+++ b/commafeed-client/src/locales/ja/messages.po
@@ -50,6 +50,10 @@ msgstr "追加"
 msgid "Add category"
 msgstr "カテゴリを追加"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "ユーザー追加"
@@ -270,6 +274,10 @@ msgstr "適用されるカスタムCSSルール"
 msgid "Custom JS code that will be executed on page load"
 msgstr "ページ読み込み時に実行されるカスタムJSコード"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "シアン"
@@ -286,6 +294,10 @@ msgstr "作成日"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "日"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "グレー"
 msgid "Green"
 msgstr "グリーン"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "ID"
@@ -627,17 +643,26 @@ msgstr "ページを下に移動"
 msgid "Move the page up"
 msgstr "ページを上に移動"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "該当なし"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "名前"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "右クリック"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "スクロール"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "検索"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "テスト"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "テスト通知が正常に送信されました。"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/ko/messages.po
+++ b/commafeed-client/src/locales/ko/messages.po
@@ -50,6 +50,10 @@ msgstr "추가"
 msgid "Add category"
 msgstr "카테고리 추가"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "사용자 추가"
@@ -270,6 +274,10 @@ msgstr "적용될 사용자 정의 CSS 규칙"
 msgid "Custom JS code that will be executed on page load"
 msgstr "페이지 로드 시 실행될 사용자 정의 JS 코드"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "시안"
@@ -286,6 +294,10 @@ msgstr "생성 날짜"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "일"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "그레이"
 msgid "Green"
 msgstr "그린"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "ID"
@@ -627,17 +643,26 @@ msgstr "페이지를 아래로 이동"
 msgid "Move the page up"
 msgstr "페이지를 위로 이동"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "해당 없음"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "이름"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "오른쪽 클릭"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "스크롤"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "검색"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "테스트"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "테스트 알림이 성공적으로 전송되었습니다."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/ms/messages.po
+++ b/commafeed-client/src/locales/ms/messages.po
@@ -50,6 +50,10 @@ msgstr "Tambah"
 msgid "Add category"
 msgstr "Tambah kategori"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Tambah pengguna"
@@ -270,6 +274,10 @@ msgstr "Aturan CSS tersuai yang akan digunakan"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Kod JS tersuai yang akan dilaksanakan semasa memuatkan halaman"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Sian"
@@ -286,6 +294,10 @@ msgstr "Tarikh dibuat"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "hari"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Kelabu"
 msgid "Green"
 msgstr "Hijau"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Gerakkan halaman ke bawah"
 msgid "Move the page up"
 msgstr "Alih halaman ke atas"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "T/A"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Nama"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Klik kanan"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Menatal"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Cari"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Ujian"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Pemberitahuan ujian berjaya dihantar."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/nb/messages.po
+++ b/commafeed-client/src/locales/nb/messages.po
@@ -50,6 +50,10 @@ msgstr "Legg til"
 msgid "Add category"
 msgstr "Legg til kategori"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Legg til bruker"
@@ -270,6 +274,10 @@ msgstr "Egendefinerte CSS-regler som vil bli brukt"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Egendefinert JS-kode som vil bli kjørt ved sideinnlasting"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Syan"
@@ -286,6 +294,10 @@ msgstr "Dato opprettet"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "dager"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Grå"
 msgid "Green"
 msgstr "Grønn"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Flytt siden ned"
 msgid "Move the page up"
 msgstr "Flytt siden opp"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/A"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Navn"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Høyreklikk"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Rulling"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Søk"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Testvarsel sendt uten feil."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/nl/messages.po
+++ b/commafeed-client/src/locales/nl/messages.po
@@ -50,6 +50,10 @@ msgstr "Toevoegen"
 msgid "Add category"
 msgstr "Categorie toevoegen"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Gebruiker toevoegen"
@@ -270,6 +274,10 @@ msgstr "Aangepaste CSS-regels die worden toegepast"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Aangepaste JS-code die wordt uitgevoerd bij het laden van de pagina"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Cyaan"
@@ -286,6 +294,10 @@ msgstr "Datum gemaakt"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "dagen"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Grijs"
 msgid "Green"
 msgstr "Groen"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Verplaats de pagina naar beneden"
 msgid "Move the page up"
 msgstr "Verplaats de pagina omhoog"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "n.v.t."
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Naam"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Rechtermuisklik"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Scrollen"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Zoeken"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Testnotificatie succesvol verzonden."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/nn/messages.po
+++ b/commafeed-client/src/locales/nn/messages.po
@@ -50,6 +50,10 @@ msgstr "Legg til"
 msgid "Add category"
 msgstr "Legg til kategori"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Legg til brukar"
@@ -270,6 +274,10 @@ msgstr "Eigne CSS-reglar som vil bli brukte"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Eige JS-kode som vil bli køyrt når sida lastar"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Syan"
@@ -286,6 +294,10 @@ msgstr "Dato opprettet"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "dagar"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Grå"
 msgid "Green"
 msgstr "Grøn"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Flytt siden ned"
 msgid "Move the page up"
 msgstr "Flytt siden opp"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "–"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Navn"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Høgreklikk"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Rulling"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Søk"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Testvarsling sendt utan feil."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/pl/messages.po
+++ b/commafeed-client/src/locales/pl/messages.po
@@ -50,6 +50,10 @@ msgstr "Dodaj"
 msgid "Add category"
 msgstr "Dodaj kategorię"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Dodaj użytkownika"
@@ -270,6 +274,10 @@ msgstr "Niestandardowe reguły CSS, które zostaną zastosowane"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Niestandardowy kod JS, który zostanie wykonany po załadowaniu strony"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Błękitny"
@@ -286,6 +294,10 @@ msgstr "Data utworzenia"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "dni"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Szary"
 msgid "Green"
 msgstr "Zielony"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Identyfikator"
@@ -627,17 +643,26 @@ msgstr "Przesuń stronę w dół"
 msgid "Move the page up"
 msgstr "Przesuń stronę w górę"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "nie dotyczy"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Nazwa"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Prawe kliknięcie"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Przewijanie"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Szukaj"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Testowe powiadomienie wysłane pomyślnie."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/pt/messages.po
+++ b/commafeed-client/src/locales/pt/messages.po
@@ -50,6 +50,10 @@ msgstr "Adicionar"
 msgid "Add category"
 msgstr "Adicionar categoria"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Adicionar usuário"
@@ -270,6 +274,10 @@ msgstr "Regras CSS personalizadas que serão aplicadas"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Código JS personalizado que será executado ao carregar a página"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Ciano"
@@ -286,6 +294,10 @@ msgstr "Data de criação"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "dias"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Cinza"
 msgid "Green"
 msgstr "Verde"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "ID"
@@ -627,17 +643,26 @@ msgstr "Mova a página para baixo"
 msgid "Move the page up"
 msgstr "Mover a página para cima"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/D"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Nome"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Clique com o botão direito"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Deslizar"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Pesquisar"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Teste"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Notificação de teste enviada com sucesso."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/ru/messages.po
+++ b/commafeed-client/src/locales/ru/messages.po
@@ -50,6 +50,10 @@ msgstr "Добавить"
 msgid "Add category"
 msgstr "Добавить категорию"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Добавить пользователя"
@@ -270,6 +274,10 @@ msgstr "Пользовательские правила CSS, которые бу
 msgid "Custom JS code that will be executed on page load"
 msgstr "Пользовательский JS-код, который будет выполняться при загрузке страницы"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Голубой"
@@ -286,6 +294,10 @@ msgstr "Дата создания"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "дней"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Серый"
 msgid "Green"
 msgstr "Зеленый"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Идентификатор"
@@ -627,17 +643,26 @@ msgstr "Переместить страницу вниз"
 msgid "Move the page up"
 msgstr "Переместить страницу вверх"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "Н/Д"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Имя"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Правый клик"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Прокрутка"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Поиск"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Тест"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Тестовое уведомление успешно отправлено."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/sk/messages.po
+++ b/commafeed-client/src/locales/sk/messages.po
@@ -50,6 +50,10 @@ msgstr "Pridať"
 msgid "Add category"
 msgstr "Pridať kategóriu"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Pridať užívateľa"
@@ -270,6 +274,10 @@ msgstr "Vlastné pravidlá CSS, ktoré sa použijú"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Vlastný kód JS, ktorý sa vykoná pri načítaní stránky"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Azúrová"
@@ -286,6 +294,10 @@ msgstr "Dátum vytvorenia"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "dni"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Sivá"
 msgid "Green"
 msgstr "Zelená"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Posuňte stránku nadol"
 msgid "Move the page up"
 msgstr "Posuňte stránku nahor"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/A"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Meno"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Kliknutie pravým tlačidlom"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Rolovanie"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Hľadaj"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Testovacie oznámenie bolo úspešne odoslané."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/sv/messages.po
+++ b/commafeed-client/src/locales/sv/messages.po
@@ -50,6 +50,10 @@ msgstr "Lägg till"
 msgid "Add category"
 msgstr "Lägg till kategori"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Lägg till användare"
@@ -270,6 +274,10 @@ msgstr "Egna CSS-regler som kommer att tillämpas"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Egen JS-kod som kommer att köras vid sidladdning"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Cyan"
@@ -286,6 +294,10 @@ msgstr "Datum skapat"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "dagar"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Grå"
 msgid "Green"
 msgstr "Grön"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Id"
@@ -627,17 +643,26 @@ msgstr "Flytta sidan nedåt"
 msgid "Move the page up"
 msgstr "Flytta sidan uppåt"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "N/A"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "Namn"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Högerklick"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Rullning"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Sök"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Testnotifiering skickades utan fel."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/tr/messages.po
+++ b/commafeed-client/src/locales/tr/messages.po
@@ -50,6 +50,10 @@ msgstr "Ekle"
 msgid "Add category"
 msgstr "Kategori ekle"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "Kullanıcı ekle"
@@ -270,6 +274,10 @@ msgstr "Uygulanacak özel CSS kuralları"
 msgid "Custom JS code that will be executed on page load"
 msgstr "Sayfa yüklendiğinde çalıştırılacak özel JS kodu"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "Macenta"
@@ -286,6 +294,10 @@ msgstr "Oluşturulma tarihi"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "gün"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "Gri"
 msgid "Green"
 msgstr "Yeşil"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "Kimlik"
@@ -627,17 +643,26 @@ msgstr "Sayfayı aşağı taşı"
 msgid "Move the page up"
 msgstr "Sayfayı yukarı taşı"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "Yok"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "İsim"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "Sağ tık"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "Kaydırma"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "Ara"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "Test"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "Test bildirimi başarıyla gönderildi."
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/locales/zh/messages.po
+++ b/commafeed-client/src/locales/zh/messages.po
@@ -50,6 +50,10 @@ msgstr "添加"
 msgid "Add category"
 msgstr "添加类别"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Add destination"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Add user"
 msgstr "添加用户"
@@ -270,6 +274,10 @@ msgstr "将被应用的自定义CSS规则"
 msgid "Custom JS code that will be executed on page load"
 msgstr "将在页面加载时执行的自定义JS代码"
 
+#: src/pages/app/SettingsPage.tsx
+msgid "Custom sharing"
+msgstr ""
+
 #: src/components/settings/DisplaySettings.tsx
 msgid "Cyan"
 msgstr "青"
@@ -286,6 +294,10 @@ msgstr "创建日期"
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "days"
 msgstr "天"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Define your own share destinations. Sharing an entry opens the URL pattern in a new window, with these placeholders replaced by the entry's values:"
+msgstr ""
 
 #: src/pages/app/CategoryDetailsPage.tsx
 msgid "Delete"
@@ -478,6 +490,10 @@ msgstr "灰"
 msgid "Green"
 msgstr "绿"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Icon is required"
+msgstr ""
+
 #: src/pages/admin/AdminUsersPage.tsx
 msgid "Id"
 msgstr "序号"
@@ -627,17 +643,26 @@ msgstr "下移页面"
 msgid "Move the page up"
 msgstr "上移页面"
 
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Must start with http:// or https://"
+msgstr ""
+
 #: src/components/RelativeDate.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "N/A"
 msgstr "不适用"
 
 #: src/components/admin/UserEdit.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/pages/admin/AdminUsersPage.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
 #: src/pages/app/FeedDetailsPage.tsx
 msgid "Name"
 msgstr "​​名称"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "Name is required"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Navigate to a subscription by entering its name"
@@ -881,6 +906,7 @@ msgstr "右键单击"
 
 #: src/components/admin/UserEdit.tsx
 #: src/components/settings/CustomCodeSettings.tsx
+#: src/components/settings/CustomSharingSettings.tsx
 #: src/components/settings/ProfileSettings.tsx
 #: src/components/settings/PushNotificationSettings.tsx
 #: src/pages/app/CategoryDetailsPage.tsx
@@ -904,6 +930,10 @@ msgstr "滚动"
 #: src/components/sidebar/TreeSearch.tsx
 msgid "Search"
 msgstr "搜索"
+
+#: src/components/settings/IconPicker.tsx
+msgid "Search icons"
+msgstr ""
 
 #: src/components/KeyboardShortcutsHelp.tsx
 msgid "Select next unread feed/category"
@@ -1062,6 +1092,10 @@ msgstr "测试"
 #: src/components/settings/PushNotificationSettings.tsx
 msgid "Test notification sent successfully."
 msgstr "测试通知发送成功。"
+
+#: src/components/settings/CustomSharingSettings.tsx
+msgid "The rest of the pattern depends on the service you are using - check its documentation for the address that adds a link. For example, Readeck:"
+msgstr ""
 
 #: src/components/content/add/Subscribe.tsx
 msgid "The URL for the feed you want to subscribe to. You can also use the website's url directly and CommaFeed will try to find the feed in the page."

--- a/commafeed-client/src/pages/WelcomePage.tsx
+++ b/commafeed-client/src/pages/WelcomePage.tsx
@@ -1,8 +1,7 @@
 import { msg } from "@lingui/core/macro"
 import { Anchor, Box, Center, Container, Divider, Group, Image, Space, Title, useMantineColorScheme } from "@mantine/core"
 import { useAsyncCallback } from "react-async-hook"
-import { SiGithub, SiX } from "react-icons/si"
-import { TbClock, TbKey, TbMoon, TbSettings, TbSun, TbUserPlus } from "react-icons/tb"
+import { TbBrandGithub, TbBrandX, TbClock, TbKey, TbMoon, TbSettings, TbSun, TbUserPlus } from "react-icons/tb"
 import { client } from "@/app/client"
 import { redirectToApiDocumentation, redirectToLogin, redirectToRegistration, redirectToRootCategory } from "@/app/redirect/thunks"
 import { useAppDispatch, useAppSelector } from "@/app/store"
@@ -138,10 +137,10 @@ function Footer() {
             <Group>
                 <span>© CommaFeed</span>
                 <Anchor variant="text" href="https://github.com/Athou/commafeed/" target="_blank" rel="noreferrer">
-                    <SiGithub />
+                    <TbBrandGithub />
                 </Anchor>
                 <Anchor variant="text" href="https://x.com/CommaFeed" target="_blank" rel="noreferrer">
-                    <SiX />
+                    <TbBrandX />
                 </Anchor>
             </Group>
             <Box>

--- a/commafeed-client/src/pages/app/SettingsPage.tsx
+++ b/commafeed-client/src/pages/app/SettingsPage.tsx
@@ -1,7 +1,8 @@
 import { Trans } from "@lingui/react/macro"
 import { Container, Tabs } from "@mantine/core"
-import { TbBell, TbCode, TbPhoto, TbUser } from "react-icons/tb"
+import { TbBell, TbCode, TbPhoto, TbShare2, TbUser } from "react-icons/tb"
 import { CustomCodeSettings } from "@/components/settings/CustomCodeSettings"
+import { CustomSharingSettings } from "@/components/settings/CustomSharingSettings"
 import { DisplaySettings } from "@/components/settings/DisplaySettings"
 import { ProfileSettings } from "@/components/settings/ProfileSettings"
 import { PushNotificationSettings } from "@/components/settings/PushNotificationSettings"
@@ -17,6 +18,9 @@ export function SettingsPage() {
                     <Tabs.Tab value="push-notifications" leftSection={<TbBell size={16} />}>
                         <Trans>Push notifications</Trans>
                     </Tabs.Tab>
+                    <Tabs.Tab value="customSharing" leftSection={<TbShare2 size={16} />}>
+                        <Trans>Custom sharing</Trans>
+                    </Tabs.Tab>
                     <Tabs.Tab value="customCode" leftSection={<TbCode size={16} />}>
                         <Trans>Custom code</Trans>
                     </Tabs.Tab>
@@ -31,6 +35,10 @@ export function SettingsPage() {
 
                 <Tabs.Panel value="push-notifications" pt="xl">
                     <PushNotificationSettings />
+                </Tabs.Panel>
+
+                <Tabs.Panel value="customSharing" pt="xl">
+                    <CustomSharingSettings />
                 </Tabs.Panel>
 
                 <Tabs.Panel value="customCode" pt="xl">

--- a/commafeed-server/src/main/java/com/commafeed/backend/model/UserSettings.java
+++ b/commafeed-server/src/main/java/com/commafeed/backend/model/UserSettings.java
@@ -2,7 +2,9 @@ package com.commafeed.backend.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -12,8 +14,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -21,6 +25,8 @@ import org.hibernate.annotations.JdbcTypeCode;
 
 import java.io.Serializable;
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "USERSETTINGS")
@@ -158,6 +164,13 @@ public class UserSettings extends AbstractModel {
     @Embedded
     private PushNotificationUserSettings pushNotifications = new PushNotificationUserSettings();
 
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "USERSETTINGS_CUSTOM_SHARING",
+            joinColumns = @JoinColumn(name = "usersettings_id"))
+    @OrderColumn(name = "position")
+    private List<CustomSharingDestination> customSharingDestinations = new ArrayList<>();
+
     @Embeddable
     @SuppressWarnings("serial")
     @Getter
@@ -178,5 +191,23 @@ public class UserSettings extends AbstractModel {
 
         @Column(name = "push_notification_topic", length = 256)
         private String topic;
+    }
+
+    @Embeddable
+    @SuppressWarnings("serial")
+    @Getter
+    @Setter
+    // value semantics let UserREST skip rewriting the collection (a full delete + re-insert of
+    // the child table) when an unrelated settings tab is saved and the destinations are unchanged
+    @EqualsAndHashCode
+    public static class CustomSharingDestination implements Serializable {
+        @Column(name = "name", length = 128, nullable = false)
+        private String name;
+
+        @Column(name = "url_pattern", length = 1024, nullable = false)
+        private String urlPattern;
+
+        @Column(name = "icon", length = 64, nullable = false)
+        private String icon;
     }
 }

--- a/commafeed-server/src/main/java/com/commafeed/frontend/model/Settings.java
+++ b/commafeed-server/src/main/java/com/commafeed/frontend/model/Settings.java
@@ -13,6 +13,8 @@ import lombok.Data;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 @SuppressWarnings("serial")
 @Schema(description = "User settings")
@@ -101,6 +103,9 @@ public class Settings implements Serializable {
     @Schema(description = "push notification settings", required = true)
     private PushNotificationSettings pushNotificationSettings = new PushNotificationSettings();
 
+    @Schema(description = "custom sharing destinations", required = true)
+    private List<CustomSharingDestination> customSharingDestinations = new ArrayList<>();
+
     @Schema(description = "User notification settings")
     @Data
     public static class PushNotificationSettings implements Serializable {
@@ -143,5 +148,20 @@ public class Settings implements Serializable {
 
         @Schema(required = true)
         private boolean buffer;
+    }
+
+    @Schema(description = "A user-defined sharing destination")
+    @Data
+    public static class CustomSharingDestination implements Serializable {
+        @Schema(required = true)
+        private String name;
+
+        @Schema(description = "URL pattern with ${url} and ${title} placeholders", required = true)
+        private String urlPattern;
+
+        @Schema(
+                description = "react-icons/si icon component name, e.g. SiWallabag",
+                required = true)
+        private String icon;
     }
 }

--- a/commafeed-server/src/main/java/com/commafeed/frontend/resource/UserREST.java
+++ b/commafeed-server/src/main/java/com/commafeed/frontend/resource/UserREST.java
@@ -65,11 +65,16 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Path("/rest/user")
 @RolesAllowed(Roles.USER)
@@ -80,6 +85,10 @@ import java.util.UUID;
 @Singleton
 @Tag(name = "Users")
 public class UserREST {
+
+    private static final int CUSTOM_SHARING_NAME_MAX_LENGTH = 128;
+    private static final int CUSTOM_SHARING_URL_PATTERN_MAX_LENGTH = 1024;
+    private static final int CUSTOM_SHARING_ICON_MAX_LENGTH = 64;
 
     private final AuthenticationContext authenticationContext;
     private final UserDAO userDAO;
@@ -144,6 +153,19 @@ public class UserREST {
                 s.getPushNotificationSettings()
                         .setTopic(settings.getPushNotifications().getTopic());
             }
+
+            s.setCustomSharingDestinations(
+                    settings.getCustomSharingDestinations().stream()
+                            .map(
+                                    d -> {
+                                        Settings.CustomSharingDestination dto =
+                                                new Settings.CustomSharingDestination();
+                                        dto.setName(d.getName());
+                                        dto.setUrlPattern(d.getUrlPattern());
+                                        dto.setIcon(d.getIcon());
+                                        return dto;
+                                    })
+                            .toList());
         } else {
             s.setReadingMode(ReadingMode.UNREAD);
             s.setReadingOrder(ReadingOrder.DESC);
@@ -180,6 +202,7 @@ public class UserREST {
     @Operation(summary = "Save user settings", description = "Save user settings")
     public Response saveUserSettings(@Parameter(required = true) Settings settings) {
         Preconditions.checkNotNull(settings);
+        validateCustomSharingDestinations(settings.getCustomSharingDestinations());
 
         User user = authenticationContext.getCurrentUser();
         UserSettings s = userSettingsDAO.findByUser(user);
@@ -227,8 +250,81 @@ public class UserREST {
         s.setInstapaper(settings.getSharingSettings().isInstapaper());
         s.setBuffer(settings.getSharingSettings().isBuffer());
 
+        List<UserSettings.CustomSharingDestination> destinations =
+                Objects.requireNonNullElse(
+                                settings.getCustomSharingDestinations(),
+                                List.<Settings.CustomSharingDestination>of())
+                        .stream()
+                        .map(
+                                d -> {
+                                    UserSettings.CustomSharingDestination e =
+                                            new UserSettings.CustomSharingDestination();
+                                    e.setName(d.getName());
+                                    e.setUrlPattern(d.getUrlPattern());
+                                    e.setIcon(d.getIcon());
+                                    return e;
+                                })
+                        .collect(Collectors.toCollection(ArrayList::new));
+        // every settings tab posts the whole Settings object back, and replacing the collection
+        // makes hibernate delete and re-insert every row of the child table, so only touch it
+        // when the destinations actually changed
+        if (!destinations.equals(s.getCustomSharingDestinations())) {
+            s.setCustomSharingDestinations(destinations);
+        }
+
         userSettingsDAO.merge(s);
         return Response.ok().build();
+    }
+
+    private void validateCustomSharingDestinations(
+            List<Settings.CustomSharingDestination> destinations) {
+        if (destinations == null) {
+            return;
+        }
+
+        Set<String> names = new HashSet<>();
+        for (Settings.CustomSharingDestination d : destinations) {
+            String name = d.getName();
+            if (StringUtils.isBlank(name)) {
+                throw new BadRequestException("custom sharing destination name must not be blank");
+            }
+            // lengths mirror the column definitions in db.changelog-7.4.xml, so an oversized
+            // value is rejected here instead of failing at flush time with a raw SQL error
+            if (name.length() > CUSTOM_SHARING_NAME_MAX_LENGTH) {
+                throw new BadRequestException(
+                        "custom sharing destination name must be at most "
+                                + CUSTOM_SHARING_NAME_MAX_LENGTH
+                                + " characters");
+            }
+            // the name is the button's identity in the UI, so duplicates would be indistinguishable
+            if (!names.add(name.toLowerCase(Locale.ROOT))) {
+                throw new BadRequestException(
+                        "custom sharing destination names must be unique: " + name);
+            }
+
+            String pattern = d.getUrlPattern();
+            if (StringUtils.isBlank(pattern) || !Urls.isAbsolute(pattern)) {
+                throw new BadRequestException(
+                        "custom sharing destination URL pattern must start with http:// or https://");
+            }
+            if (pattern.length() > CUSTOM_SHARING_URL_PATTERN_MAX_LENGTH) {
+                throw new BadRequestException(
+                        "custom sharing destination URL pattern must be at most "
+                                + CUSTOM_SHARING_URL_PATTERN_MAX_LENGTH
+                                + " characters");
+            }
+
+            String icon = d.getIcon();
+            if (StringUtils.isBlank(icon)) {
+                throw new BadRequestException("custom sharing destination icon must not be blank");
+            }
+            if (icon.length() > CUSTOM_SHARING_ICON_MAX_LENGTH) {
+                throw new BadRequestException(
+                        "custom sharing destination icon must be at most "
+                                + CUSTOM_SHARING_ICON_MAX_LENGTH
+                                + " characters");
+            }
+        }
     }
 
     @Path("/pushNotificationTest")

--- a/commafeed-server/src/main/resources/changelogs/db.changelog-7.4.xml
+++ b/commafeed-server/src/main/resources/changelogs/db.changelog-7.4.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+	<changeSet id="create-custom-sharing-table" author="athou">
+		<createTable tableName="USERSETTINGS_CUSTOM_SHARING">
+			<column name="usersettings_id" type="BIGINT">
+				<constraints nullable="false" primaryKey="true" />
+			</column>
+			<column name="position" type="INT">
+				<constraints nullable="false" primaryKey="true" />
+			</column>
+			<column name="name" type="VARCHAR(128)">
+				<constraints nullable="false" />
+			</column>
+			<column name="url_pattern" type="VARCHAR(1024)">
+				<constraints nullable="false" />
+			</column>
+			<column name="icon" type="VARCHAR(64)">
+				<constraints nullable="false" />
+			</column>
+		</createTable>
+
+		<addForeignKeyConstraint constraintName="fk_usersettings_custom_sharing_usersettings_id"
+								  baseTableName="USERSETTINGS_CUSTOM_SHARING" baseColumnNames="usersettings_id"
+								  referencedTableName="USERSETTINGS" referencedColumnNames="id"
+								  onDelete="CASCADE" />
+	</changeSet>
+
+</databaseChangeLog>

--- a/commafeed-server/src/main/resources/migrations.xml
+++ b/commafeed-server/src/main/resources/migrations.xml
@@ -39,5 +39,6 @@
 	<include file="changelogs/db.changelog-5.12.xml" />
 	<include file="changelogs/db.changelog-7.0.xml" />
 	<include file="changelogs/db.changelog-7.2.xml" />
+	<include file="changelogs/db.changelog-7.4.xml" />
 
-</databaseChangeLog> 
+</databaseChangeLog>

--- a/commafeed-server/src/test/java/com/commafeed/integration/rest/UserIT.java
+++ b/commafeed-server/src/test/java/com/commafeed/integration/rest/UserIT.java
@@ -120,4 +120,154 @@ class UserIT extends BaseIT {
                 RestAssured.given().get("rest/user/settings").then().extract().as(Settings.class);
         Assertions.assertEquals("test", updatedSettings.getLanguage());
     }
+
+    @Test
+    void saveCustomSharingDestinations() {
+        Settings settings =
+                RestAssured.given().get("rest/user/settings").then().extract().as(Settings.class);
+
+        Settings.CustomSharingDestination destination = new Settings.CustomSharingDestination();
+        destination.setName("Wallabag");
+        destination.setUrlPattern("https://example.com/save?url=${url}");
+        destination.setIcon("SiWallabag");
+        settings.setCustomSharingDestinations(List.of(destination));
+
+        RestAssured.given()
+                .body(settings)
+                .contentType(ContentType.JSON)
+                .post("rest/user/settings")
+                .then()
+                .statusCode(200);
+
+        Settings updatedSettings =
+                RestAssured.given().get("rest/user/settings").then().extract().as(Settings.class);
+        Assertions.assertEquals(1, updatedSettings.getCustomSharingDestinations().size());
+        Settings.CustomSharingDestination updatedDestination =
+                updatedSettings.getCustomSharingDestinations().getFirst();
+        Assertions.assertEquals("Wallabag", updatedDestination.getName());
+        Assertions.assertEquals(
+                "https://example.com/save?url=${url}", updatedDestination.getUrlPattern());
+        Assertions.assertEquals("SiWallabag", updatedDestination.getIcon());
+    }
+
+    @Test
+    void rejectsCustomSharingDestinationWithInvalidScheme() {
+        Settings settings =
+                RestAssured.given().get("rest/user/settings").then().extract().as(Settings.class);
+
+        Settings.CustomSharingDestination destination = new Settings.CustomSharingDestination();
+        destination.setName("Malicious");
+        destination.setUrlPattern("javascript:alert(1)");
+        destination.setIcon("SiWallabag");
+        settings.setCustomSharingDestinations(List.of(destination));
+
+        RestAssured.given()
+                .body(settings)
+                .contentType(ContentType.JSON)
+                .post("rest/user/settings")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void rejectsCustomSharingDestinationWithBlankName() {
+        Settings settings =
+                RestAssured.given().get("rest/user/settings").then().extract().as(Settings.class);
+
+        Settings.CustomSharingDestination destination = new Settings.CustomSharingDestination();
+        destination.setName("");
+        destination.setUrlPattern("https://example.com/save?url=${url}");
+        destination.setIcon("SiWallabag");
+        settings.setCustomSharingDestinations(List.of(destination));
+
+        RestAssured.given()
+                .body(settings)
+                .contentType(ContentType.JSON)
+                .post("rest/user/settings")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void acceptsCustomSharingDestinationWithUppercaseScheme() {
+        Settings settings =
+                RestAssured.given().get("rest/user/settings").then().extract().as(Settings.class);
+
+        Settings.CustomSharingDestination destination = new Settings.CustomSharingDestination();
+        destination.setName("Uppercase");
+        destination.setUrlPattern("HTTPS://example.com/save?url=${url}");
+        destination.setIcon("SiWallabag");
+        settings.setCustomSharingDestinations(List.of(destination));
+
+        RestAssured.given()
+                .body(settings)
+                .contentType(ContentType.JSON)
+                .post("rest/user/settings")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void rejectsCustomSharingDestinationWithTooLongName() {
+        Settings settings =
+                RestAssured.given().get("rest/user/settings").then().extract().as(Settings.class);
+
+        Settings.CustomSharingDestination destination = new Settings.CustomSharingDestination();
+        destination.setName("a".repeat(129));
+        destination.setUrlPattern("https://example.com/save?url=${url}");
+        destination.setIcon("SiWallabag");
+        settings.setCustomSharingDestinations(List.of(destination));
+
+        RestAssured.given()
+                .body(settings)
+                .contentType(ContentType.JSON)
+                .post("rest/user/settings")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void rejectsCustomSharingDestinationWithTooLongUrlPattern() {
+        Settings settings =
+                RestAssured.given().get("rest/user/settings").then().extract().as(Settings.class);
+
+        Settings.CustomSharingDestination destination = new Settings.CustomSharingDestination();
+        destination.setName("Long");
+        destination.setUrlPattern("https://example.com/?q=" + "a".repeat(1024));
+        destination.setIcon("SiWallabag");
+        settings.setCustomSharingDestinations(List.of(destination));
+
+        RestAssured.given()
+                .body(settings)
+                .contentType(ContentType.JSON)
+                .post("rest/user/settings")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void rejectsCustomSharingDestinationsWithDuplicateNames() {
+        Settings settings =
+                RestAssured.given().get("rest/user/settings").then().extract().as(Settings.class);
+
+        Settings.CustomSharingDestination first = new Settings.CustomSharingDestination();
+        first.setName("Readeck");
+        first.setUrlPattern("https://example.com/save?url=${url}");
+        first.setIcon("SiWallabag");
+
+        Settings.CustomSharingDestination second = new Settings.CustomSharingDestination();
+        // same name in a different case: they would be indistinguishable in the share menu
+        second.setName("readeck");
+        second.setUrlPattern("https://other.example.com/save?url=${url}");
+        second.setIcon("SiPinboard");
+
+        settings.setCustomSharingDestinations(List.of(first, second));
+
+        RestAssured.given()
+                .body(settings)
+                .contentType(ContentType.JSON)
+                .post("rest/user/settings")
+                .then()
+                .statusCode(400);
+    }
 }


### PR DESCRIPTION
Lets users define their own share destinations, stored server-side per user so they're portable across browsers/devices instead of living in localStorage.

Backend:
- UserSettings.CustomSharingDestination embeddable + @ElementCollection (name, urlPattern, icon), new USERSETTINGS_CUSTOM_SHARING table (db.changelog-7.4.xml)
- Settings DTO mirror + UserREST mapping and validation (non-blank name/icon, unique names case-insensitively, http(s)-only urlPattern, length limits)

Frontend:
- Custom Sharing settings tab: add/edit/remove destinations, with an icon picker limited to react-icons/si (Simple Icons), lazy-loaded so the ~3300-icon module never lands in the main bundle
- ShareButtons renders configured destinations alongside the built-in services, substituting ${url}/${title} placeholders into the URL pattern and opening it in a new window with window.opener cleared
- Built-in share icons (gmail/facebook/x/tumblr/instapaper/buffer) now resolve through the same lazy si-icons loader instead of a static import, to keep them out of the main bundle too

Tests: 7 new UserIT cases (round-trip, invalid scheme, blank name, uppercase scheme, name/url length limits, duplicate names) and a new customSharing.test.ts for URL-pattern substitution.